### PR TITLE
ES-6: connect database and add models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # EliteSpace-BackEnd
 
-A modern, secure backend service powering the Elite Space tenant portal. This service handles digital lease management, smart device integration, complaint management, and various tenant-focused features to enhance the apartment living experience.
+The backend service powering the Elite Space tenant portal. This service handles digital lease management, smart device integration, complaint management, and various tenant-focused features to enhance the apartment living experience.
 
 ## Tech Stack
 
 - **Runtime**: Node.js
 - **Framework**: Express.js with TypeScript
-- **Database**: PostgreSQL
+- **Database**: PostgreSQL hosted on Supabase
 - **ORM**: Drizzle ORM
 - **Authentication**: Supabase Auth
 
@@ -19,12 +19,13 @@ A modern, secure backend service powering the Elite Space tenant portal. This se
 - Parking permit management
 - Guest access management
 
-## Environment Setup
+## 🚀 Getting Started
+
+### Local Setup
 
 1. Clone the repository:
 ```bash
-git clone [repository-url]
-cd [repository-name]
+git clone https://github.com/EliteSpace-DSD/EliteSpace-BackEnd.git
 ```
 
 2. Install dependencies:
@@ -32,16 +33,118 @@ cd [repository-name]
 npm install
 ```
 
-## Development
+3. Set up environment variables:
+``` 
+DATABASE_URL=[your-database-connection-url]
+```
 
-Start the development server:
+4. Start the development server:
 ```bash
 npm run start
 ```
+Your server will run at [http://localhost:3000](http://localhost:3000)
 
-The server will start on `http://localhost:3000`
+## 🌳 Git Branching & Workflow
+🔹 Creating branch from JIRA
+1. Go to the JIRA issue you're working on
+2. Click on "Create branch" in Jira (on the issue page)
+3. Go to the terminal and run: `git fetch`
+4. Switch to the newly created branch: `git checkout ES-21-Create-README`
 
-## Project Structure
+This automatically links your branch, commits and PRs to the JIRA issue.
+
+🔹 Creating a branch manually
+If creating manually, always branch from main:
+````
+git checkout main
+git pull
+git checkout -b <issue-key>-<short-description>
+````
+
+Example: `git checkout -b ES-21-Create-README`
+
+Include the Jira issue key (e.g., ES-21) to automatically link your branch to the issue. This helps track progress, commits, and PRs directly in Jira.
 
 
-## API Endpoints
+## 🔄 Committing Changes (Conventional Commits)
+
+### Use Conventional Commit messages for consistency:
+
+Format: ```git commit -m "<type>(optional scope): <description>"```
+
+Examples:
+```
+git commit -m "feat(guest): add temporary guest parking feature"
+git commit -m "fix(auth): resolve login redirect issue"
+git commit -m "docs(readme): update local setup instructions"
+```
+
+### Commit Types:
+- feat: New feature
+- fix: Bug fix
+- docs: Documentation changes
+- style: Style-related changes
+- refactor: Code refactoring
+- chore: Maintenance tasks
+- test: Adding/improving tests
+
+
+Read more here: https://www.conventionalcommits.org/en/v1.0.0/ 
+
+## 🔀 Pushing & Merging Branches
+1. Rebase Your Branch (Before Pushing)
+
+Before pushing your changes, ensure your branch is up-to-date with main:
+```
+git checkout main
+git pull origin main
+
+git checkout <your-branch-name>
+git rebase main
+```
+Resolve any conflicts if they arise.
+
+Continue rebasing after resolving conflicts:
+```
+git add .
+git rebase --continue
+```
+
+2. Push Your Branch
+
+`git push origin <your-branch-name>`
+
+
+3. Open a Pull Request (PR):
+- Navigate to GitHub repo.
+- Click Compare & pull request.
+- Provide a descriptive title and description.
+- Link the related JIRA issue (e.g., APT-101).
+
+4. Request a Review:
+- Assign the PR to a reviewer (1 leads and 1 other team member).
+- Address comments promptly.
+- How to add meaningful comments during code review: https://conventionalcomments.org/
+
+5. Merge After Approval:
+- Merge using Squash and Merge option.
+- Delete your branch after merging.
+
+
+## 💬 Comments & Documentation
+Inline Comments: Use clear comments to explain complex logic.
+
+PR Descriptions: Always include what was done, why, and how to test. Screenshot of the visual change is always reccommended. 
+
+Example PR Description:
+
+```
+### Description:
+Adds endpoint to create a temporary guest parking passes in db.
+
+### How to test:
+- Open an HTTP client (HTTPie, Postman, Thunder Client vscode extension).
+- Make a POST request to /parking.
+- Verify 201 response received with correct parking pass details.
+
+```

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+    out: './src/db/migrations',
+    schema: './src/db/schema.ts',
+    dialect: 'postgresql',
+    dbCredentials: {
+        url: process.env.DATABASE_URL!,
+    },
+    verbose: true,
+    strict: true,
+});

--- a/package.json
+++ b/package.json
@@ -6,20 +6,28 @@
   "scripts": {
     "build": "tsc",
     "start": "nodemon ./src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "db:generate": "npx drizzle-kit generate",
+    "db:migrate": "npx drizzle-kit migrate",
+    "db:drop": "npx drizzle-kit drop",
+    "db:view": "npx drizzle-kit studio"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "dotenv": "^16.4.7",
+    "drizzle-orm": "^0.39.3",
     "express": "^4.21.2",
     "morgan": "^1.10.0",
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "postgres": "^3.4.5"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/morgan": "^1.9.9",
     "@types/node": "^22.13.5",
+    "drizzle-kit": "^0.30.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3"
   }

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -1,0 +1,36 @@
+# Database Overview
+
+The database is a PostgreSQL instance hosted on Supabase. There is also a storage bucket initialized in Supabase for the project.
+
+There is a production and a development database.
+
+## Initialization
+
+The database connection is initialized in the `index.ts` file and requires a variable called `DATABASE_URL` set in the `.env` file, which corresponds to the connection string from Supabase.
+
+## Object-Relational Mapping (ORM)
+
+The ORM tool used to interact with the database is Drizzle. It is a TypeScript-based tool that provides a way to interact with the database in a way that is relational and SQL-like queries. This can help make it easier to interact with the database in the code environment while having an interface that is similar to SQL.
+Documentation can be found [here](https://orm.drizzle.team/docs/overview).
+
+## Migrations
+
+Migrations are handled with Drizzle Kit. Documentation can be found [here](https://orm.drizzle.team/docs/drizzle-kit).
+
+There are 3 commands that can be used to manage the database:
+
+- `db:generate`: This runs the command `npx drizzle-kit generate` to generate a new migration. This is used to create a new migration when a new model is added or when changes are made to the existing models.
+
+- `db:migrate`: Runs the command `npx drizzle-kit migrate` to apply migrations. This command applies the latest migration to the database, updating the tables to the latest state.
+
+- `db:drop`: Runs the command `npx drizzle-kit drop` to delete the selected migration.
+
+## Schema
+
+The tables are defined in the `schema.ts` file. The schema defines the tables and fields for each table, as well as the relationships between all tables.
+
+The schema file also contains inferred types for each table. For example, the `tenants` table has a type called `TenantInsertType`, used to provide inferred type info for the shape of the data expected when inserting a new tenant. And a a second type called `TenantSelectType`, used to provide inferredtype info for the shape of the data returned from the database.
+
+## Models
+
+The models folder contains methods for interacting with the database tables, for example, CRUD operations. Each table is referred to as a model, and functions for each table are defined in the respective model file.

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config'
+
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import * as schema from './schema'
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+    throw new Error('connectionString is not defined')
+};
+
+// Disable prefetch as it is not supported for "Transaction" pool mode
+export const client = postgres(connectionString, { prepare: false })
+export const db = drizzle(client, { schema, casing: 'snake_case' });

--- a/src/db/migrations/0000_next_jack_power.sql
+++ b/src/db/migrations/0000_next_jack_power.sql
@@ -1,0 +1,142 @@
+CREATE TYPE "public"."access_code_type" AS ENUM('resident', 'guest');--> statement-breakpoint
+CREATE TYPE "public"."complaint_type" AS ENUM('noise', 'other');--> statement-breakpoint
+CREATE TYPE "public"."issue_type" AS ENUM('hvac', 'plumbing', 'other');--> statement-breakpoint
+CREATE TYPE "public"."maintenance_status" AS ENUM('open', 'closed');--> statement-breakpoint
+CREATE TYPE "public"."package_status" AS ENUM('delivered', 'retrieved');--> statement-breakpoint
+CREATE TABLE "access_codes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid,
+	"type" "access_code_type" NOT NULL,
+	"hashed_code" varchar(255) NOT NULL,
+	"expires_at" timestamp with time zone,
+	"is_active" boolean DEFAULT true,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "buildings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"address" text NOT NULL,
+	"city" text NOT NULL,
+	"state" text NOT NULL,
+	"zip" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "complaints" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid,
+	"issue_type" "complaint_type" NOT NULL,
+	"description" text NOT NULL,
+	"priority" text NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "leases" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"unit_tenants_id" uuid,
+	"start_date" date NOT NULL,
+	"end_date" date NOT NULL,
+	"monthly_rate" numeric(10, 2) NOT NULL,
+	"document" text,
+	"status" text NOT NULL,
+	"signed_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "maintenance_requests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid,
+	"unit_id" uuid,
+	"issue_type" "issue_type" NOT NULL,
+	"description" text NOT NULL,
+	"status" "maintenance_status" DEFAULT 'open',
+	"resolution" text,
+	"completed_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "packages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid,
+	"locker_id" uuid,
+	"locker_code" varchar(10),
+	"status" "package_status" DEFAULT 'delivered',
+	"delivery_time" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "parking_permits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid,
+	"guest_name" text,
+	"license_plate" varchar(20) NOT NULL,
+	"parking_space" integer,
+	"expires_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "smart_lockers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"building_id" uuid,
+	"locker_number" integer NOT NULL,
+	"is_occupied" boolean DEFAULT false,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tenants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"age" integer,
+	"email" varchar(255) NOT NULL,
+	"phone" text,
+	"password_hash" varchar(255) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tenants_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "unit_tenants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid,
+	"unit_id" uuid,
+	"move_in_date" date NOT NULL,
+	"move_out_date" date,
+	"is_primary" boolean DEFAULT false,
+	"is_active" boolean DEFAULT true,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "units" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"building_id" uuid,
+	"unit_number" integer NOT NULL,
+	"square_feet" integer,
+	"vacant" boolean DEFAULT true,
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "access_codes" ADD CONSTRAINT "access_codes_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "complaints" ADD CONSTRAINT "complaints_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "leases" ADD CONSTRAINT "leases_unit_tenants_id_unit_tenants_id_fk" FOREIGN KEY ("unit_tenants_id") REFERENCES "public"."unit_tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "maintenance_requests" ADD CONSTRAINT "maintenance_requests_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "maintenance_requests" ADD CONSTRAINT "maintenance_requests_unit_id_units_id_fk" FOREIGN KEY ("unit_id") REFERENCES "public"."units"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "packages" ADD CONSTRAINT "packages_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "packages" ADD CONSTRAINT "packages_locker_id_smart_lockers_id_fk" FOREIGN KEY ("locker_id") REFERENCES "public"."smart_lockers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "parking_permits" ADD CONSTRAINT "parking_permits_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "smart_lockers" ADD CONSTRAINT "smart_lockers_building_id_buildings_id_fk" FOREIGN KEY ("building_id") REFERENCES "public"."buildings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "unit_tenants" ADD CONSTRAINT "unit_tenants_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "unit_tenants" ADD CONSTRAINT "unit_tenants_unit_id_units_id_fk" FOREIGN KEY ("unit_id") REFERENCES "public"."units"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "units" ADD CONSTRAINT "units_building_id_buildings_id_fk" FOREIGN KEY ("building_id") REFERENCES "public"."buildings"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/db/migrations/meta/0000_snapshot.json
+++ b/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,968 @@
+{
+  "id": "9a72a9e9-4a2c-4022-825f-f2b890d9f361",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_codes": {
+      "name": "access_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "access_code_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_code": {
+          "name": "hashed_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "access_codes_tenant_id_tenants_id_fk": {
+          "name": "access_codes_tenant_id_tenants_id_fk",
+          "tableFrom": "access_codes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.buildings": {
+      "name": "buildings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.complaints": {
+      "name": "complaints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "complaint_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "complaints_tenant_id_tenants_id_fk": {
+          "name": "complaints_tenant_id_tenants_id_fk",
+          "tableFrom": "complaints",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leases": {
+      "name": "leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "unit_tenants_id": {
+          "name": "unit_tenants_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_rate": {
+          "name": "monthly_rate",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document": {
+          "name": "document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leases_unit_tenants_id_unit_tenants_id_fk": {
+          "name": "leases_unit_tenants_id_unit_tenants_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "unit_tenants",
+          "columnsFrom": [
+            "unit_tenants_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_requests": {
+      "name": "maintenance_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_id": {
+          "name": "unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "maintenance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_requests_tenant_id_tenants_id_fk": {
+          "name": "maintenance_requests_tenant_id_tenants_id_fk",
+          "tableFrom": "maintenance_requests",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maintenance_requests_unit_id_units_id_fk": {
+          "name": "maintenance_requests_unit_id_units_id_fk",
+          "tableFrom": "maintenance_requests",
+          "tableTo": "units",
+          "columnsFrom": [
+            "unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locker_id": {
+          "name": "locker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locker_code": {
+          "name": "locker_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "package_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'delivered'"
+        },
+        "delivery_time": {
+          "name": "delivery_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_tenant_id_tenants_id_fk": {
+          "name": "packages_tenant_id_tenants_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_locker_id_smart_lockers_id_fk": {
+          "name": "packages_locker_id_smart_lockers_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "smart_lockers",
+          "columnsFrom": [
+            "locker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parking_permits": {
+      "name": "parking_permits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_plate": {
+          "name": "license_plate",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parking_space": {
+          "name": "parking_space",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parking_permits_tenant_id_tenants_id_fk": {
+          "name": "parking_permits_tenant_id_tenants_id_fk",
+          "tableFrom": "parking_permits",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.smart_lockers": {
+      "name": "smart_lockers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "building_id": {
+          "name": "building_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locker_number": {
+          "name": "locker_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_occupied": {
+          "name": "is_occupied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "smart_lockers_building_id_buildings_id_fk": {
+          "name": "smart_lockers_building_id_buildings_id_fk",
+          "tableFrom": "smart_lockers",
+          "tableTo": "buildings",
+          "columnsFrom": [
+            "building_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_email_unique": {
+          "name": "tenants_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unit_tenants": {
+      "name": "unit_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_id": {
+          "name": "unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "move_in_date": {
+          "name": "move_in_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "move_out_date": {
+          "name": "move_out_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "unit_tenants_tenant_id_tenants_id_fk": {
+          "name": "unit_tenants_tenant_id_tenants_id_fk",
+          "tableFrom": "unit_tenants",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "unit_tenants_unit_id_units_id_fk": {
+          "name": "unit_tenants_unit_id_units_id_fk",
+          "tableFrom": "unit_tenants",
+          "tableTo": "units",
+          "columnsFrom": [
+            "unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.units": {
+      "name": "units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "building_id": {
+          "name": "building_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_number": {
+          "name": "unit_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "square_feet": {
+          "name": "square_feet",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vacant": {
+          "name": "vacant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "units_building_id_buildings_id_fk": {
+          "name": "units_building_id_buildings_id_fk",
+          "tableFrom": "units",
+          "tableTo": "buildings",
+          "columnsFrom": [
+            "building_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_code_type": {
+      "name": "access_code_type",
+      "schema": "public",
+      "values": [
+        "resident",
+        "guest"
+      ]
+    },
+    "public.complaint_type": {
+      "name": "complaint_type",
+      "schema": "public",
+      "values": [
+        "noise",
+        "other"
+      ]
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "public",
+      "values": [
+        "hvac",
+        "plumbing",
+        "other"
+      ]
+    },
+    "public.maintenance_status": {
+      "name": "maintenance_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.package_status": {
+      "name": "package_status",
+      "schema": "public",
+      "values": [
+        "delivered",
+        "retrieved"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1740430588918,
+      "tag": "0000_next_jack_power",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/models/accessCodes.ts
+++ b/src/db/models/accessCodes.ts
@@ -3,21 +3,41 @@ import { eq } from 'drizzle-orm';
 import { accessCodes, AccessCodeInsertType } from '../schema';
 
 export const createAccessCode = async (accessCode: AccessCodeInsertType) => {
-    const result = await db.insert(accessCodes).values(accessCode)
-    return result[0];
+    try {
+        const result = await db.insert(accessCodes).values(accessCode).returning();
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const getAccessCodesByTenantId = async (tenantId: string) => {
-    const result = await db.select().from(accessCodes).where(eq(accessCodes.tenantId, tenantId));
-    return result;
+    try {
+        const result = await db.select().from(accessCodes).where(eq(accessCodes.tenantId, tenantId));
+        return result || [];
+    } catch (error) {
+        return [];
+    }
 };
 
 export const deleteAccessCode = async (accessCodeId: string) => {
-    const result = await db.delete(accessCodes).where(eq(accessCodes.id, accessCodeId));
-    return result[0];
+    try {
+        const result = await db.delete(accessCodes).where(eq(accessCodes.id, accessCodeId)).returning();
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };
 
 export const deactivateAccessCode = async (accessCodeId: string) => {
-    const result = await db.update(accessCodes).set({ isActive: false }).where(eq(accessCodes.id, accessCodeId));
-    return result[0];
+    try {
+        const result = await db.update(accessCodes)
+            .set({ isActive: false })
+            .where(eq(accessCodes.id, accessCodeId))
+            .returning();
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };

--- a/src/db/models/accessCodes.ts
+++ b/src/db/models/accessCodes.ts
@@ -1,0 +1,23 @@
+import { db } from '../index';
+import { eq } from 'drizzle-orm';
+import { accessCodes, AccessCodeInsertType } from '../schema';
+
+export const createAccessCode = async (accessCode: AccessCodeInsertType) => {
+    const result = await db.insert(accessCodes).values(accessCode)
+    return result[0];
+};
+
+export const getAccessCodesByTenantId = async (tenantId: string) => {
+    const result = await db.select().from(accessCodes).where(eq(accessCodes.tenantId, tenantId));
+    return result;
+};
+
+export const deleteAccessCode = async (accessCodeId: string) => {
+    const result = await db.delete(accessCodes).where(eq(accessCodes.id, accessCodeId));
+    return result[0];
+};
+
+export const deactivateAccessCode = async (accessCodeId: string) => {
+    const result = await db.update(accessCodes).set({ isActive: false }).where(eq(accessCodes.id, accessCodeId));
+    return result[0];
+};

--- a/src/db/models/complaint.ts
+++ b/src/db/models/complaint.ts
@@ -3,21 +3,41 @@ import { eq } from 'drizzle-orm';
 import { ComplaintInsertType, complaints } from '../schema';
 
 export const createComplaint = async (complaint: ComplaintInsertType) => {
-    const result = await db.insert(complaints).values(complaint).returning();
-    return result[0];
+    try {
+        const result = await db.insert(complaints).values(complaint).returning();
+        return result[0] || null;
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getComplaintsByTenantId = async (tenantId: string) => {
-    const result = await db.select().from(complaints).where(eq(complaints.tenantId, tenantId));
-    return result;
+    try {
+        const result = await db.select().from(complaints).where(eq(complaints.tenantId, tenantId));
+        return result || [];
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
 };
 
 export const updateComplaintPriority = async (complaintId: string, priority: string) => {
-    const result = await db.update(complaints).set({ priority }).where(eq(complaints.id, complaintId));
-    return result[0];
+    try {
+        const result = await db.update(complaints).set({ priority }).where(eq(complaints.id, complaintId));
+        return result[0] || null;
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const deleteComplaint = async (complaintId: string) => {
-    const result = await db.delete(complaints).where(eq(complaints.id, complaintId));
-    return result[0];
+    try {
+        const result = await db.delete(complaints).where(eq(complaints.id, complaintId));
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };

--- a/src/db/models/complaint.ts
+++ b/src/db/models/complaint.ts
@@ -1,0 +1,23 @@
+import { db } from '../index';
+import { eq } from 'drizzle-orm';
+import { ComplaintInsertType, complaints } from '../schema';
+
+export const createComplaint = async (complaint: ComplaintInsertType) => {
+    const result = await db.insert(complaints).values(complaint).returning();
+    return result[0];
+};
+
+export const getComplaintsByTenantId = async (tenantId: string) => {
+    const result = await db.select().from(complaints).where(eq(complaints.tenantId, tenantId));
+    return result;
+};
+
+export const updateComplaintPriority = async (complaintId: string, priority: string) => {
+    const result = await db.update(complaints).set({ priority }).where(eq(complaints.id, complaintId));
+    return result[0];
+};
+
+export const deleteComplaint = async (complaintId: string) => {
+    const result = await db.delete(complaints).where(eq(complaints.id, complaintId));
+    return result[0];
+};

--- a/src/db/models/lease.ts
+++ b/src/db/models/lease.ts
@@ -1,0 +1,58 @@
+import { db } from '../index';
+import { eq, and } from 'drizzle-orm';
+import { leases, unitTenants, LeaseInsertType } from '../schema';
+
+export const createLease = async (lease: LeaseInsertType) => {
+    const result = await db.insert(leases).values(lease);
+    return result;
+};
+
+export const getLeaseById = async (leaseId: string) => {
+    const result = await db.select().from(leases).where(eq(leases.id, leaseId));
+    return result;
+};
+
+export const getLeasesByTenantId = async (tenantId: string) => {
+    const result = await db.query.unitTenants.findMany({
+        where: eq(unitTenants.tenantId, tenantId),
+        with: {
+            unit: true,
+            leases: true,
+        },
+    });
+    return result;
+};
+
+export const getActiveLease = async (tenantsId: string) => {
+    const unitTenantId = await db.query.unitTenants.findFirst({
+        where: and(
+            eq(unitTenants.tenantId, tenantsId),
+            eq(unitTenants.isPrimary, true)
+        ),
+        columns: {
+            id: true,
+        }
+    });
+
+    if (!unitTenantId) {
+        return;
+    }
+
+    const result = await db.query.leases.findFirst({
+        where: and(
+            eq(leases.unitTenantsId, unitTenantId.id),
+            eq(leases.status, 'active')
+        )
+    });
+
+    if (!result) {
+        return;
+    }
+
+    return result;
+}
+
+export const deleteLease = async (leaseId: string) => {
+    const result = await db.delete(leases).where(eq(leases.id, leaseId));
+    return result;
+};

--- a/src/db/models/lease.ts
+++ b/src/db/models/lease.ts
@@ -3,56 +3,77 @@ import { eq, and } from 'drizzle-orm';
 import { leases, unitTenants, LeaseInsertType } from '../schema';
 
 export const createLease = async (lease: LeaseInsertType) => {
-    const result = await db.insert(leases).values(lease);
-    return result;
+    try {
+        const result = await db.insert(leases).values(lease).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getLeaseById = async (leaseId: string) => {
-    const result = await db.select().from(leases).where(eq(leases.id, leaseId));
-    return result;
+    try {
+        const result = await db.select().from(leases).where(eq(leases.id, leaseId));
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getLeasesByTenantId = async (tenantId: string) => {
-    const result = await db.query.unitTenants.findMany({
-        where: eq(unitTenants.tenantId, tenantId),
-        with: {
-            unit: true,
-            leases: true,
-        },
-    });
-    return result;
+    try {
+        const result = await db.query.unitTenants.findMany({
+            where: eq(unitTenants.tenantId, tenantId),
+            with: {
+                unit: true,
+                leases: true,
+            },
+        });
+        return result || [];
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
 };
 
 export const getActiveLease = async (tenantsId: string) => {
-    const unitTenantId = await db.query.unitTenants.findFirst({
-        where: and(
-            eq(unitTenants.tenantId, tenantsId),
-            eq(unitTenants.isPrimary, true)
-        ),
-        columns: {
-            id: true,
+    try {
+        const unitTenantId = await db.query.unitTenants.findFirst({
+            where: and(
+                eq(unitTenants.tenantId, tenantsId),
+                eq(unitTenants.isPrimary, true)
+            ),
+            columns: {
+                id: true,
+            }
+        });
+
+        if (!unitTenantId) {
+            return null;
         }
-    });
 
-    if (!unitTenantId) {
-        return;
+        const result = await db.query.leases.findFirst({
+            where: and(
+                eq(leases.unitTenantsId, unitTenantId.id),
+                eq(leases.status, 'active')
+            )
+        });
+
+        return result;
+    } catch (error) {
+        console.error(error);
+        return null;
     }
-
-    const result = await db.query.leases.findFirst({
-        where: and(
-            eq(leases.unitTenantsId, unitTenantId.id),
-            eq(leases.status, 'active')
-        )
-    });
-
-    if (!result) {
-        return;
-    }
-
-    return result;
-}
+};
 
 export const deleteLease = async (leaseId: string) => {
-    const result = await db.delete(leases).where(eq(leases.id, leaseId));
-    return result;
+    try {
+        const result = await db.delete(leases).where(eq(leases.id, leaseId)).returning();
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };

--- a/src/db/models/maintenanceRequest.ts
+++ b/src/db/models/maintenanceRequest.ts
@@ -1,0 +1,42 @@
+import { db } from '../index';
+import { eq, and } from 'drizzle-orm';
+import { MaintenanceRequestInsertType, maintenanceRequests, MaintenanceStatus, IssueType } from '../schema';
+import { getUnitIdByTenantId } from './unitTenant';
+
+export const createMaintenanceRequest = async (maintenanceRequest: MaintenanceRequestInsertType) => {
+    if (!maintenanceRequest.tenantId) return;
+
+    const unitId = await getUnitIdByTenantId(maintenanceRequest.tenantId);
+    const requestObj = {
+        ...maintenanceRequest,
+        unitId: unitId,
+    }
+
+    const result = await db.insert(maintenanceRequests).values(requestObj).returning();
+    return result[0];
+};
+
+export const getMaintenanceRequests = async (tenantId: string) => {
+    const unitId = await getUnitIdByTenantId(tenantId);
+    if (!unitId) return;
+
+    const result = await db.select().from(maintenanceRequests).where(
+        and(
+            eq(maintenanceRequests.tenantId, tenantId),
+            eq(maintenanceRequests.unitId, unitId),
+        )
+    );
+
+    return result;
+};
+
+export const updateRequestStatus = async (maintenanceRequestId: string, status: MaintenanceStatus) => {
+    const result = await db.update(maintenanceRequests).set({ status }).where(eq(maintenanceRequests.id, maintenanceRequestId));
+    return result[0];
+};
+
+
+export const deleteRequest = async (maintenanceRequestId: string) => {
+    const result = await db.delete(maintenanceRequests).where(eq(maintenanceRequests.id, maintenanceRequestId));
+    return result[0];
+};

--- a/src/db/models/maintenanceRequest.ts
+++ b/src/db/models/maintenanceRequest.ts
@@ -4,39 +4,58 @@ import { MaintenanceRequestInsertType, maintenanceRequests, MaintenanceStatus, I
 import { getUnitIdByTenantId } from './unitTenant';
 
 export const createMaintenanceRequest = async (maintenanceRequest: MaintenanceRequestInsertType) => {
-    if (!maintenanceRequest.tenantId) return;
+    try {
+        if (!maintenanceRequest.tenantId) return null;
 
-    const unitId = await getUnitIdByTenantId(maintenanceRequest.tenantId);
-    const requestObj = {
-        ...maintenanceRequest,
-        unitId: unitId,
+        const unitId = await getUnitIdByTenantId(maintenanceRequest.tenantId);
+        const requestObj = {
+            ...maintenanceRequest,
+            unitId: unitId,
+        }
+
+        const result = await db.insert(maintenanceRequests).values(requestObj).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
     }
-
-    const result = await db.insert(maintenanceRequests).values(requestObj).returning();
-    return result[0];
 };
 
 export const getMaintenanceRequests = async (tenantId: string) => {
-    const unitId = await getUnitIdByTenantId(tenantId);
-    if (!unitId) return;
+    try {
+        const unitId = await getUnitIdByTenantId(tenantId);
+        if (!unitId) return [];
 
-    const result = await db.select().from(maintenanceRequests).where(
-        and(
-            eq(maintenanceRequests.tenantId, tenantId),
-            eq(maintenanceRequests.unitId, unitId),
-        )
-    );
+        const result = await db.select().from(maintenanceRequests).where(
+            and(
+                eq(maintenanceRequests.tenantId, tenantId),
+                eq(maintenanceRequests.unitId, unitId),
+            )
+        );
 
-    return result;
+        return result;
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
 };
 
 export const updateRequestStatus = async (maintenanceRequestId: string, status: MaintenanceStatus) => {
-    const result = await db.update(maintenanceRequests).set({ status }).where(eq(maintenanceRequests.id, maintenanceRequestId));
-    return result[0];
+    try {
+        const result = await db.update(maintenanceRequests).set({ status }).where(eq(maintenanceRequests.id, maintenanceRequestId));
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
-
 export const deleteRequest = async (maintenanceRequestId: string) => {
-    const result = await db.delete(maintenanceRequests).where(eq(maintenanceRequests.id, maintenanceRequestId));
-    return result[0];
+    try {
+        const result = await db.delete(maintenanceRequests).where(eq(maintenanceRequests.id, maintenanceRequestId));
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };

--- a/src/db/models/packages.ts
+++ b/src/db/models/packages.ts
@@ -1,0 +1,31 @@
+import { db } from '../index';
+import { eq, and } from 'drizzle-orm';
+import { packages, PackageInsertType } from '../schema';
+
+export const createPackage = async (packageDetails: PackageInsertType) => {
+    const result = await db.insert(packages).values(packageDetails).returning();
+    return result[0];
+};
+
+export const getPackageById = async (packageId: string) => {
+    const result = await db.select().from(packages).where(eq(packages.id, packageId));
+    return result[0];
+};
+
+export const getPackagesByTenantId = async (tenantId: string) => {
+    const result = await db.query.packages.findMany({
+        where: and(
+            eq(packages.tenantId, tenantId),
+            eq(packages.status, 'delivered')
+        ),
+        with: {
+            smartLocker: {
+                columns: {
+                    id: true,
+                    lockerNumber: true
+                }
+            }
+        }
+    });
+    return result;
+};

--- a/src/db/models/packages.ts
+++ b/src/db/models/packages.ts
@@ -3,29 +3,44 @@ import { eq, and } from 'drizzle-orm';
 import { packages, PackageInsertType } from '../schema';
 
 export const createPackage = async (packageDetails: PackageInsertType) => {
-    const result = await db.insert(packages).values(packageDetails).returning();
-    return result[0];
+    try {
+        const result = await db.insert(packages).values(packageDetails).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getPackageById = async (packageId: string) => {
-    const result = await db.select().from(packages).where(eq(packages.id, packageId));
-    return result[0];
+    try {
+        const result = await db.select().from(packages).where(eq(packages.id, packageId));
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getPackagesByTenantId = async (tenantId: string) => {
-    const result = await db.query.packages.findMany({
-        where: and(
-            eq(packages.tenantId, tenantId),
-            eq(packages.status, 'delivered')
-        ),
-        with: {
-            smartLocker: {
-                columns: {
-                    id: true,
-                    lockerNumber: true
+    try {
+        const result = await db.query.packages.findMany({
+            where: and(
+                eq(packages.tenantId, tenantId),
+                eq(packages.status, 'delivered')
+            ),
+            with: {
+                smartLocker: {
+                    columns: {
+                        id: true,
+                        lockerNumber: true
+                    }
                 }
             }
-        }
-    });
-    return result;
+        });
+        return result;
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
 };

--- a/src/db/models/parkingPermit.ts
+++ b/src/db/models/parkingPermit.ts
@@ -3,21 +3,41 @@ import { eq } from 'drizzle-orm';
 import { parkingPermits, ParkingPermitInsertType } from '../schema';
 
 export const createParkingPermit = async (parkingPermit: ParkingPermitInsertType) => {
-    const result = await db.insert(parkingPermits).values(parkingPermit).returning();
-    return result[0];
+    try {
+        const result = await db.insert(parkingPermits).values(parkingPermit).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getParkingPermitByTenantId = async (tenantId: string) => {
-    const result = await db.select().from(parkingPermits).where(eq(parkingPermits.tenantId, tenantId));
-    return result[0];
+    try {
+        const result = await db.select().from(parkingPermits).where(eq(parkingPermits.tenantId, tenantId));
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const extendParkingPermit = async (id: string, expiresAt: Date) => {
-    const result = await db.update(parkingPermits).set({ expiresAt }).where(eq(parkingPermits.id, id));
-    return result[0];
+    try {
+        const result = await db.update(parkingPermits).set({ expiresAt }).where(eq(parkingPermits.id, id));
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const deleteParkingPermit = async (id: string) => {
-    const result = await db.delete(parkingPermits).where(eq(parkingPermits.id, id));
-    return result[0];
+    try {
+        const result = await db.delete(parkingPermits).where(eq(parkingPermits.id, id));
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };

--- a/src/db/models/parkingPermit.ts
+++ b/src/db/models/parkingPermit.ts
@@ -1,0 +1,23 @@
+import { db } from '../index';
+import { eq } from 'drizzle-orm';
+import { parkingPermits, ParkingPermitInsertType } from '../schema';
+
+export const createParkingPermit = async (parkingPermit: ParkingPermitInsertType) => {
+    const result = await db.insert(parkingPermits).values(parkingPermit).returning();
+    return result[0];
+};
+
+export const getParkingPermitByTenantId = async (tenantId: string) => {
+    const result = await db.select().from(parkingPermits).where(eq(parkingPermits.tenantId, tenantId));
+    return result[0];
+};
+
+export const extendParkingPermit = async (id: string, expiresAt: Date) => {
+    const result = await db.update(parkingPermits).set({ expiresAt }).where(eq(parkingPermits.id, id));
+    return result[0];
+};
+
+export const deleteParkingPermit = async (id: string) => {
+    const result = await db.delete(parkingPermits).where(eq(parkingPermits.id, id));
+    return result[0];
+};

--- a/src/db/models/smartLocker.ts
+++ b/src/db/models/smartLocker.ts
@@ -1,0 +1,45 @@
+import { db } from '../index';
+import { eq, and } from 'drizzle-orm';
+import { smartLockers, SmartLockerInsertType } from '../schema';
+
+export const createSmartLocker = async (smartLocker: SmartLockerInsertType) => {
+    const result = await db.insert(smartLockers).values(smartLocker).returning();
+    return result[0];
+};
+
+export const getSmartLockerById = async (id: string) => {
+    const result = await db.select().from(smartLockers).where(eq(smartLockers.id, id));
+    return result[0];
+};
+
+export const getOpenSmartLocker = async () => {
+    const result = await db.query.smartLockers.findFirst({
+        where: eq(smartLockers.isOccupied, false),
+        columns: {
+            id: true,
+            lockerNumber: true
+        }
+    });
+    return result;
+};
+
+export const getAllOpenSmartLockers = async () => {
+    const result = await db.query.smartLockers.findMany({
+        where: eq(smartLockers.isOccupied, false),
+        columns: {
+            id: true,
+            lockerNumber: true
+        }
+    });
+    return result;
+};
+
+export const updateSmartLockerStatus = async (id: string, isOccupied: boolean) => {
+    const result = await db.update(smartLockers).set({ isOccupied }).where(eq(smartLockers.id, id));
+    return result[0];
+};
+
+export const deleteSmartLocker = async (id: string) => {
+    const result = await db.delete(smartLockers).where(eq(smartLockers.id, id));
+    return result[0];
+};

--- a/src/db/models/smartLocker.ts
+++ b/src/db/models/smartLocker.ts
@@ -3,43 +3,68 @@ import { eq, and } from 'drizzle-orm';
 import { smartLockers, SmartLockerInsertType } from '../schema';
 
 export const createSmartLocker = async (smartLocker: SmartLockerInsertType) => {
-    const result = await db.insert(smartLockers).values(smartLocker).returning();
-    return result[0];
+    try {
+        const result = await db.insert(smartLockers).values(smartLocker).returning();
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const getSmartLockerById = async (id: string) => {
-    const result = await db.select().from(smartLockers).where(eq(smartLockers.id, id));
-    return result[0];
+    try {
+        const result = await db.select().from(smartLockers).where(eq(smartLockers.id, id));
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const getOpenSmartLocker = async () => {
-    const result = await db.query.smartLockers.findFirst({
-        where: eq(smartLockers.isOccupied, false),
-        columns: {
-            id: true,
-            lockerNumber: true
-        }
-    });
-    return result;
+    try {
+        const result = await db.query.smartLockers.findFirst({
+            where: eq(smartLockers.isOccupied, false),
+            columns: {
+                id: true,
+                lockerNumber: true
+            }
+        });
+        return result;
+    } catch (error) {
+        return null;
+    }
 };
 
 export const getAllOpenSmartLockers = async () => {
-    const result = await db.query.smartLockers.findMany({
-        where: eq(smartLockers.isOccupied, false),
-        columns: {
-            id: true,
-            lockerNumber: true
-        }
-    });
-    return result;
+    try {
+        const result = await db.query.smartLockers.findMany({
+            where: eq(smartLockers.isOccupied, false),
+            columns: {
+                id: true,
+                lockerNumber: true
+            }
+        });
+        return result || [];
+    } catch (error) {
+        return [];
+    }
 };
 
 export const updateSmartLockerStatus = async (id: string, isOccupied: boolean) => {
-    const result = await db.update(smartLockers).set({ isOccupied }).where(eq(smartLockers.id, id));
-    return result[0];
+    try {
+        const result = await db.update(smartLockers).set({ isOccupied }).where(eq(smartLockers.id, id));
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const deleteSmartLocker = async (id: string) => {
-    const result = await db.delete(smartLockers).where(eq(smartLockers.id, id));
-    return result[0];
+    try {
+        const result = await db.delete(smartLockers).where(eq(smartLockers.id, id));
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };

--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -1,0 +1,26 @@
+import { db } from '../index';
+import { eq } from 'drizzle-orm';
+import { tenants, TenantInsertType } from '../schema';
+
+export const createTenant = async (tenant: TenantInsertType) => {
+    const result = await db.insert(tenants).values(tenant).returning();
+    return result[0];
+};
+
+export const getTenantById = async (tenantId: string) => {
+    const result = await db.select().from(tenants).where(eq(tenants.id, tenantId));
+    return result[0];
+};
+
+export const updateTenant = async (tenantId: string, updates: Partial<TenantInsertType>) => {
+    const result = await db.update(tenants)
+        .set(updates)
+        .where(eq(tenants.id, tenantId))
+        .returning();
+    return result[0];
+};
+
+export const deleteTenant = async (tenantId: string) => {
+    await db.delete(tenants).where(eq(tenants.id, tenantId));
+    return;
+};

--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -3,24 +3,40 @@ import { eq } from 'drizzle-orm';
 import { tenants, TenantInsertType } from '../schema';
 
 export const createTenant = async (tenant: TenantInsertType) => {
-    const result = await db.insert(tenants).values(tenant).returning();
-    return result[0];
+    try {
+        const result = await db.insert(tenants).values(tenant).returning();
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const getTenantById = async (tenantId: string) => {
-    const result = await db.select().from(tenants).where(eq(tenants.id, tenantId));
-    return result[0];
+    try {
+        const result = await db.select().from(tenants).where(eq(tenants.id, tenantId));
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const updateTenant = async (tenantId: string, updates: Partial<TenantInsertType>) => {
-    const result = await db.update(tenants)
-        .set(updates)
-        .where(eq(tenants.id, tenantId))
-        .returning();
-    return result[0];
+    try {
+        const result = await db.update(tenants)
+            .set(updates)
+            .where(eq(tenants.id, tenantId))
+            .returning();
+        return result[0];
+    } catch (error) {
+        return null;
+    }
 };
 
 export const deleteTenant = async (tenantId: string) => {
-    await db.delete(tenants).where(eq(tenants.id, tenantId));
-    return;
+    try {
+        const result = await db.delete(tenants).where(eq(tenants.id, tenantId));
+        return { success: true };
+    } catch (error) {
+        return { success: false };
+    }
 };

--- a/src/db/models/unit.ts
+++ b/src/db/models/unit.ts
@@ -1,0 +1,23 @@
+import { db } from '../index';
+import { eq } from 'drizzle-orm';
+import { units, UnitInsertType, unitTenants } from '../schema';
+
+export const createUnit = async (unit: UnitInsertType) => {
+    const result = await db.insert(units).values(unit).returning();
+    return result[0];
+};
+
+export const getUnitById = async (unitId: string) => {
+    const result = await db.select().from(units).where(eq(units.id, unitId));
+    return result[0];
+};
+
+export const updateUnit = async (unitId: string, updates: Partial<UnitInsertType>) => {
+    const result = await db.update(units).set(updates).where(eq(units.id, unitId)).returning();
+    return result[0];
+};
+
+export const deleteUnit = async (unitId: string) => {
+    const result = await db.delete(units).where(eq(units.id, unitId));
+    return result[0];
+};

--- a/src/db/models/unit.ts
+++ b/src/db/models/unit.ts
@@ -3,21 +3,41 @@ import { eq } from 'drizzle-orm';
 import { units, UnitInsertType, unitTenants } from '../schema';
 
 export const createUnit = async (unit: UnitInsertType) => {
-    const result = await db.insert(units).values(unit).returning();
-    return result[0];
+    try {
+        const result = await db.insert(units).values(unit).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getUnitById = async (unitId: string) => {
-    const result = await db.select().from(units).where(eq(units.id, unitId));
-    return result[0];
+    try {
+        const result = await db.select().from(units).where(eq(units.id, unitId));
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const updateUnit = async (unitId: string, updates: Partial<UnitInsertType>) => {
-    const result = await db.update(units).set(updates).where(eq(units.id, unitId)).returning();
-    return result[0];
+    try {
+        const result = await db.update(units).set(updates).where(eq(units.id, unitId)).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const deleteUnit = async (unitId: string) => {
-    const result = await db.delete(units).where(eq(units.id, unitId));
-    return result[0];
+    try {
+        const result = await db.delete(units).where(eq(units.id, unitId));
+        return { success: true };
+    } catch (error) {
+        console.error(error);
+        return { success: false };
+    }
 };

--- a/src/db/models/unitTenant.ts
+++ b/src/db/models/unitTenant.ts
@@ -3,48 +3,68 @@ import { eq, and } from 'drizzle-orm';
 import { unitTenants, UnitTenantInsertType } from '../schema';
 
 export const createUnitTenant = async (unitTenant: UnitTenantInsertType) => {
-    const result = await db.insert(unitTenants).values(unitTenant).returning();
-    return result[0];
+    try {
+        const result = await db.insert(unitTenants).values(unitTenant).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getAllUnitTenants = async (unitId: string) => {
-    const tenants = await db.query.unitTenants.findMany({
-        where: eq(unitTenants.unitId, unitId),
-        with: {
-            tenant: true,
-        }
-    });
-    return tenants;
+    try {
+        const tenants = await db.query.unitTenants.findMany({
+            where: eq(unitTenants.unitId, unitId),
+            with: {
+                tenant: true,
+            }
+        });
+        return tenants || [];
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
 };
 
 export const getPrimaryTenant = async (unitId: string) => {
-    const primaryTenant = await db.query.unitTenants.findFirst({
-        where: and(
-            eq(unitTenants.isPrimary, true),
-            eq(unitTenants.unitId, unitId),
-        ),
-        with: {
-            tenant: true,
-        }
-    });
-    return primaryTenant;
+    try {
+        const primaryTenant = await db.query.unitTenants.findFirst({
+            where: and(
+                eq(unitTenants.isPrimary, true),
+                eq(unitTenants.unitId, unitId),
+            ),
+            with: {
+                tenant: true,
+            }
+        });
+        return primaryTenant || null;
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
 };
 
 export const getUnitIdByTenantId = async (tenantId: string) => {
-    const unitId = await db.query.unitTenants.findFirst({
-        where: eq(unitTenants.tenantId, tenantId),
-        with: {
-            unit: {
-                columns: {
-                    id: true,
+    try {
+        const unitId = await db.query.unitTenants.findFirst({
+            where: eq(unitTenants.tenantId, tenantId),
+            with: {
+                unit: {
+                    columns: {
+                        id: true,
+                    }
                 }
             }
-        }
-    });
+        });
 
-    if (!unitId) {
+        if (!unitId) {
+            return null;
+        }
+
+        return unitId.unit?.id;
+    } catch (error) {
+        console.error(error);
         return null;
     }
-
-    return unitId.unit?.id;
 };

--- a/src/db/models/unitTenant.ts
+++ b/src/db/models/unitTenant.ts
@@ -1,0 +1,50 @@
+import { db } from '../index';
+import { eq, and } from 'drizzle-orm';
+import { unitTenants, UnitTenantInsertType } from '../schema';
+
+export const createUnitTenant = async (unitTenant: UnitTenantInsertType) => {
+    const result = await db.insert(unitTenants).values(unitTenant).returning();
+    return result[0];
+};
+
+export const getAllUnitTenants = async (unitId: string) => {
+    const tenants = await db.query.unitTenants.findMany({
+        where: eq(unitTenants.unitId, unitId),
+        with: {
+            tenant: true,
+        }
+    });
+    return tenants;
+};
+
+export const getPrimaryTenant = async (unitId: string) => {
+    const primaryTenant = await db.query.unitTenants.findFirst({
+        where: and(
+            eq(unitTenants.isPrimary, true),
+            eq(unitTenants.unitId, unitId),
+        ),
+        with: {
+            tenant: true,
+        }
+    });
+    return primaryTenant;
+};
+
+export const getUnitIdByTenantId = async (tenantId: string) => {
+    const unitId = await db.query.unitTenants.findFirst({
+        where: eq(unitTenants.tenantId, tenantId),
+        with: {
+            unit: {
+                columns: {
+                    id: true,
+                }
+            }
+        }
+    });
+
+    if (!unitId) {
+        return null;
+    }
+
+    return unitId.unit?.id;
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,246 @@
+import { relations } from 'drizzle-orm';
+import {
+    pgTable,
+    uuid,
+    text,
+    varchar,
+    timestamp,
+    boolean,
+    integer,
+    date,
+    decimal,
+    pgEnum,
+} from 'drizzle-orm/pg-core';
+
+export type IssueType = 'hvac' | 'plumbing' | 'other';
+export type MaintenanceStatus = 'open' | 'closed';
+export type ComplaintType = 'noise' | 'other';
+export type PackageStatus = 'delivered' | 'retrieved';
+export type AccessCodeType = 'resident' | 'guest';
+
+export const issueTypeEnum = pgEnum('issue_type', ['hvac', 'plumbing', 'other']);
+export const maintenanceStatusEnum = pgEnum('maintenance_status', ['open', 'closed']);
+export const complaintTypeEnum = pgEnum('complaint_type', ['noise', 'other']);
+export const packageStatusEnum = pgEnum('package_status', ['delivered', 'retrieved']);
+export const accessCodeTypeEnum = pgEnum('access_code_type', ['resident', 'guest']);
+
+// Column helpers
+export const timestamps = {
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).defaultNow().notNull(),
+}
+
+// Tables
+export const buildings = pgTable('buildings', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(),
+    address: text('address').notNull(),
+    city: text('city').notNull(),
+    state: text('state').notNull(),
+    zip: text('zip').notNull(),
+    ...timestamps
+});
+
+export const units = pgTable('units', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    buildingId: uuid('building_id').references(() => buildings.id, { onDelete: 'cascade' }),
+    unitNumber: integer('unit_number').notNull(),
+    squareFeet: integer('square_feet'),
+    vacant: boolean('vacant').default(true),
+    ...timestamps
+});
+
+export const tenants = pgTable('tenants', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    firstName: text('first_name').notNull(),
+    lastName: text('last_name').notNull(),
+    age: integer('age'),
+    email: varchar('email', { length: 255 }).notNull().unique(),
+    phone: text('phone'),
+    passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+    ...timestamps
+});
+
+export const unitTenants = pgTable('unit_tenants', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').references(() => tenants.id, { onDelete: 'cascade' }),
+    unitId: uuid('unit_id').references(() => units.id, { onDelete: 'cascade' }),
+    moveInDate: date('move_in_date').notNull(),
+    moveOutDate: date('move_out_date'),
+    isPrimary: boolean('is_primary').default(false),
+    isActive: boolean('is_active').default(true),
+    ...timestamps
+});
+
+export const leases = pgTable('leases', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    unitTenantsId: uuid('unit_tenants_id').references(() => unitTenants.id, { onDelete: 'cascade' }),
+    startDate: date('start_date').notNull(),
+    endDate: date('end_date').notNull(),
+    monthlyRate: decimal('monthly_rate', { precision: 10, scale: 2 }).notNull(),
+    document: text('document'),
+    status: text('status').notNull(),
+    signedAt: timestamp('signed_at', { withTimezone: true, mode: 'date' }),
+    ...timestamps
+});
+
+export const parkingPermits = pgTable('parking_permits', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').references(() => tenants.id, { onDelete: 'cascade' }),
+    guestName: text('guest_name'),
+    licensePlate: varchar('license_plate', { length: 20 }).notNull(),
+    parkingSpace: integer('parking_space'),
+    expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }).notNull(),
+    ...timestamps
+});
+
+export const maintenanceRequests = pgTable('maintenance_requests', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').references(() => tenants.id, { onDelete: 'cascade' }),
+    unitId: uuid('unit_id').references(() => units.id, { onDelete: 'cascade' }),
+    issueType: issueTypeEnum('issue_type').notNull(),
+    description: text('description').notNull(),
+    status: maintenanceStatusEnum('status').default('open'),
+    resolution: text('resolution'),
+    completedAt: timestamp('completed_at', { withTimezone: true, mode: 'date' }),
+    ...timestamps
+});
+
+export const complaints = pgTable('complaints', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').references(() => tenants.id, { onDelete: 'cascade' }),
+    issueType: complaintTypeEnum('issue_type').notNull(),
+    description: text('description').notNull(),
+    priority: text('priority').notNull(),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true, mode: 'date' }),
+    ...timestamps
+});
+
+export const accessCodes = pgTable('access_codes', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').references(() => tenants.id, { onDelete: 'cascade' }),
+    type: accessCodeTypeEnum('type').notNull(),
+    hashedCode: varchar('hashed_code', { length: 255 }).notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }),
+    isActive: boolean('is_active').default(true),
+    ...timestamps
+});
+
+export const smartLockers = pgTable('smart_lockers', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    buildingId: uuid('building_id').references(() => buildings.id, { onDelete: 'cascade' }),
+    lockerNumber: integer('locker_number').notNull(),
+    isOccupied: boolean('is_occupied').default(false),
+    ...timestamps
+});
+
+export const packages = pgTable('packages', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id').references(() => tenants.id, { onDelete: 'cascade' }),
+    lockerId: uuid('locker_id').references(() => smartLockers.id),
+    lockerCode: varchar('locker_code', { length: 10 }),
+    status: packageStatusEnum('status').default('delivered'),
+    deliveryTime: timestamp('delivery_time', { withTimezone: true, mode: 'date' }),
+    ...timestamps
+});
+
+// Inferred types for retrieval and insertion operations
+export type BuildingSelectType = typeof buildings.$inferSelect;
+export type BuildingInsertType = typeof buildings.$inferInsert;
+
+export type UnitSelectType = typeof units.$inferSelect;
+export type UnitInsertType = typeof units.$inferInsert;
+
+export type TenantSelectType = typeof tenants.$inferSelect;
+export type TenantInsertType = typeof tenants.$inferInsert;
+
+export type UnitTenantSelectType = typeof unitTenants.$inferSelect;
+export type UnitTenantInsertType = typeof unitTenants.$inferInsert;
+
+export type LeaseSelectType = typeof leases.$inferSelect;
+export type LeaseInsertType = typeof leases.$inferInsert;
+
+export type ParkingPermitSelectType = typeof parkingPermits.$inferSelect;
+export type ParkingPermitInsertType = typeof parkingPermits.$inferInsert;
+
+export type MaintenanceRequestSelectType = typeof maintenanceRequests.$inferSelect;
+export type MaintenanceRequestInsertType = typeof maintenanceRequests.$inferInsert;
+
+export type ComplaintSelectType = typeof complaints.$inferSelect;
+export type ComplaintInsertType = typeof complaints.$inferInsert;
+
+export type AccessCodeSelectType = typeof accessCodes.$inferSelect;
+export type AccessCodeInsertType = typeof accessCodes.$inferInsert;
+
+export type SmartLockerSelectType = typeof smartLockers.$inferSelect;
+export type SmartLockerInsertType = typeof smartLockers.$inferInsert;
+
+export type PackageSelectType = typeof packages.$inferSelect;
+export type PackageInsertType = typeof packages.$inferInsert;
+
+
+// Table Relations
+export const buildingsRelations = relations(buildings, ({ many }) => ({
+    units: many(units),
+    smartLockers: many(smartLockers),
+}));
+
+export const unitsRelations = relations(units, ({ one, many }) => ({
+    building: one(buildings, {
+        fields: [units.buildingId],
+        references: [buildings.id],
+    }),
+    unitTenants: many(unitTenants),
+    maintenanceRequests: many(maintenanceRequests),
+}));
+
+export const tenantsRelations = relations(tenants, ({ many }) => ({
+    unitTenants: many(unitTenants),
+    parkingPermits: many(parkingPermits),
+    maintenanceRequests: many(maintenanceRequests),
+    complaints: many(complaints),
+    accessCodes: many(accessCodes),
+    packages: many(packages),
+}));
+
+export const unitTenantsRelations = relations(unitTenants, ({ one, many }) => ({
+    tenant: one(tenants, {
+        fields: [unitTenants.tenantId],
+        references: [tenants.id],
+    }),
+    unit: one(units, {
+        fields: [unitTenants.unitId],
+        references: [units.id],
+    }),
+    leases: many(leases),
+}));
+
+export const maintenanceRequestsRelations = relations(maintenanceRequests, ({ one }) => ({
+    unit: one(units, {
+        fields: [maintenanceRequests.unitId],
+        references: [units.id],
+    }),
+    tenant: one(tenants, {
+        fields: [maintenanceRequests.tenantId],
+        references: [tenants.id],
+    }),
+}));
+
+export const smartLockersRelations = relations(smartLockers, ({ one, many }) => ({
+    building: one(buildings, {
+        fields: [smartLockers.buildingId],
+        references: [buildings.id],
+    }),
+    packages: many(packages),
+}));
+
+export const packagesRelations = relations(packages, ({ one }) => ({
+    tenant: one(tenants, {
+        fields: [packages.tenantId],
+        references: [tenants.id],
+    }),
+    smartLocker: one(smartLockers, {
+        fields: [packages.lockerId],
+        references: [smartLockers.id],
+    })
+}));


### PR DESCRIPTION
### Description:
Adds connection to database, sets schema, and adds models for each table with functions for basic operations.

### How to test:
There is some test data in the development database.

- Connect to dev db using development database url
- Create test endpoint for db function to test
- Call function from endpoint handler, with required data object
- Test hitting endpoint from HTTP client (Thunder Client in vscode)
- Verify response

#### Example API endpoint to test with:
***tenantId** in this example is an id taken from the **tenants** table in the development db instance in Supabase. Also, this endpoint isn't set up how actual endpoint would be, but it just used as a way to quickly test db functions*

![CleanShot 2025-02-24 at 21 26 24@2x](https://github.com/user-attachments/assets/a87381f4-b9c6-4547-aa4e-130830f0700b)


#### Calling test endpoint:
- Go to endpoint in browser ex: http://localhost:3000/complaints
- Use Thunder Client VS Code extension:

![thunder_client_extension@2x](https://github.com/user-attachments/assets/21921870-06c1-4331-be27-629cb2ae988c)

![CleanShot 2025-02-24 at 21 26 58@2x](https://github.com/user-attachments/assets/e8012a7e-2f2b-4549-9a36-cc7973bee6c5)

#### Example response:

![example_response@2x](https://github.com/user-attachments/assets/97b940ea-c266-482a-b79a-4708c0667842)

Right now, the full object of row properties are being returned but this can be adjusted once we know what info we want to return and can be adjusted either from the database level or when constructing API responses.

#### Example Error log:
```shell
Error creating complaint: PostgresError: invalid input syntax for type uuid: "8eb494f7-76d7-4f2c-a6ae-4410734895555"
    at ErrorResponse (/Users/king/Desktop/elite_space/EliteSpace-BackEnd/node_modules/postgres/cjs/src/connection.js:788:26)
    at handle (/Users/king/Desktop/elite_space/EliteSpace-BackEnd/node_modules/postgres/cjs/src/connection.js:474:6)
    at Socket.data (/Users/king/Desktop/elite_space/EliteSpace-BackEnd/node_modules/postgres/cjs/src/connection.js:315:9)
    at Socket.emit (node:events:519:28)
    at Socket.emit (node:domain:488:12)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Socket.Readable.push (node:internal/streams/readable:390:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  severity_local: 'ERROR',
  severity: 'ERROR',
  code: '22P02',
  where: "unnamed portal parameter $1 = '...'",
  file: 'uuid.c',
  line: '133',
  routine: 'string_to_uuid'
}
``` 