### PR TITLE
ES-66 feat(auth): add register endpoint

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,16 +1,41 @@
-import express, {Request, Response} from 'express';
+import express, { Request, Response } from 'express';
+import { getTenantByEmail } from '../db/models/tenant';
+import { signUpNewUser, linkUserToTenant } from '../authClient/authFunctions';
 
 const router = express.Router();
 
+router.post('/register', async (req: Request, res: Response) => {
+    try {
+        const { email, password } = req.body;
+        const isExistingTenant = await getTenantByEmail(email);
 
+        if (!isExistingTenant) {
+            res.status(404).json({ message: 'Unable to register account. Contact Elite Space Leasing.' });
+            return;
+        };
 
+        const { data, error } = await signUpNewUser(email, password);
 
-// some route logics
+        if (error) {
+            console.log(error);
+            res.status(500).json({ message: 'Error signing up.' });
+            return;
+        };
 
+        if (data.user) {
+            const { error: dbError } = await linkUserToTenant(email, data.user.id);
 
+            if (dbError) {
+                throw new Error('Error linking tenant');
+            }
 
-
-
-
+            return;
+        }
+    } catch (error) {
+        console.log(error)
+        res.status(500).json({ message: 'Server error' });
+        return;
+    };
+});
 
 export default router;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -17,7 +17,8 @@ router.post('/register', async (req: Request, res: Response) => {
         const { data, error } = await signUpNewUser(email, password);
 
         if (error) {
-            res.status(500).json({ message: 'Error signing up.' });
+            const errorMsg = error.code === 'weak_password' ? 'Password not strong enough. Must be atleast 6 characters.' : 'Error signing up';
+            res.status(500).json({ message: errorMsg });
             return;
         };
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -17,7 +17,6 @@ router.post('/register', async (req: Request, res: Response) => {
         const { data, error } = await signUpNewUser(email, password);
 
         if (error) {
-            console.log(error);
             res.status(500).json({ message: 'Error signing up.' });
             return;
         };
@@ -26,13 +25,13 @@ router.post('/register', async (req: Request, res: Response) => {
             const { error: dbError } = await linkUserToTenant(email, data.user.id);
 
             if (dbError) {
-                throw new Error('Error linking tenant');
-            }
+                res.status(500).json({ message: 'Server error' });
+            };
 
+            res.status(200).json({ message: 'Account registered.' });
             return;
-        }
+        };
     } catch (error) {
-        console.log(error)
         res.status(500).json({ message: 'Server error' });
         return;
     };


### PR DESCRIPTION
## Description

Adds endpoint to register new users. This endpoint:
- Verifies that the email used to register matches an existing tenant email
- creates a new user in the auth users table
- sends verification email to confirm signup

## How to test

- Add test user to tenants table or update the email for an existing user to use a test email. [Yopmail](https://yopmail.com/) provides option for creating a disposable test email inbox

- Run local server
- use Thunder Client vscode or other http client to call test endpoint
- After endpoint is called, a new user should be created in the Users table under the Authentication tab in Supabase and the corresponding UID should be added to the tenants table

**Test error**
- Call endpoint using an email that doesn't exist in tenants table
- Should receive a 404 error with message
```
{
  "message": "Unable to register account. Contact Elite Space Leasing."
}
```