### PR TITLE
Es 36 login api endpoint - 1

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -57,13 +57,12 @@ router.post('/signin', async (req: Request, res: Response) => {
             return;
         }
 
-        const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
-
+        // access token expires_in by default is 3600 seconds, * 1000 = 3600000 milliseconds = 1 hour
         res.cookie('sb-access-token', session.access_token, {
             httpOnly: true, //Prevents JS access
             // secure: true, // only sent over HTTPS, set as true only in production
             sameSite: 'strict',
-            maxAge: session.expires_in * thirtyDaysInSeconds,
+            maxAge: session.expires_in * 1000,
 
         })
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -39,13 +39,22 @@ router.post('/register', async (req: Request, res: Response) => {
 });
 
 
-// Note: users need to confirm their email before being able to sign in
+// Note: users needs to click confirm on their confirmation email before being able to sign in
 router.post('/signin', async (req: Request, res: Response) => {
     try {
         const { email, password } = req.body;
         const {data, error} = await signInWithEmail(email, password);
-        console.log("Check Point 1");
-        console.log(data);
+
+        if (error) {
+            res.status(401).json({ message: 'Invalid email or password. Please try again.' });
+            return 
+        }
+
+        if (data) {
+            res.status(200).json({ message: 'Signed in successfully', user: data });
+            return;
+        }
+
     } catch (error) {
         res.status(500).json({message: 'Server error'});
         return;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { getTenantByEmail } from '../db/models/tenant';
-import { signUpNewUser, linkUserToTenant } from '../authClient/authFunctions';
+import { signUpNewUser, linkUserToTenant, signInWithEmail } from '../authClient/authFunctions';
 
 const router = express.Router();
 
@@ -37,5 +37,14 @@ router.post('/register', async (req: Request, res: Response) => {
         return;
     };
 });
+
+router.post('/signin', async (req: Request, res: Response) => {
+    try {
+        //do something
+    } catch (error) {
+        res.status(500).json({message: 'Server error'});
+        return;
+    }
+})
 
 export default router;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -50,10 +50,25 @@ router.post('/signin', async (req: Request, res: Response) => {
             return 
         }
 
-        if (data) {
-            res.status(200).json({ message: 'Signed in successfully', user: data });
+        // Set session cookie (for persistence)
+        const {session} = data;
+        if (!session) {
+            res.status(500).json({message: "failed to retrieve session."});
             return;
         }
+
+        const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
+
+        res.cookie('sb-access-token', session.access_token, {
+            httpOnly: true, //Prevents JS access
+            // secure: true, // only sent over HTTPS, set as true only in production
+            sameSite: 'strict',
+            maxAge: session.expires_in * thirtyDaysInSeconds,
+
+        })
+
+        res.status(200).json({ message: 'Signed in successfully'});
+        return;
 
     } catch (error) {
         res.status(500).json({message: 'Server error'});

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -38,9 +38,14 @@ router.post('/register', async (req: Request, res: Response) => {
     };
 });
 
+
+// Note: users need to confirm their email before being able to sign in
 router.post('/signin', async (req: Request, res: Response) => {
     try {
-        //do something
+        const { email, password } = req.body;
+        const {data, error} = await signInWithEmail(email, password);
+        console.log("Check Point 1");
+        console.log(data);
     } catch (error) {
         res.status(500).json({message: 'Server error'});
         return;


### PR DESCRIPTION
## Description
- This is an initial sub-process of implementing signin, (session handling (cookie issuance) will be addressed for the next PR)
- Added an endpoint for sign-in (Only available for tenants that already have clicked on the confirmation email from registration)

## Prerequisite **(SKIP Prerequisite if you have access to the password of a tenant who has already clicked on the email confirmation link.)**
- You will need to have a test tenant that already have clicked on the confirmation email from registration. If you don't have access to one then create it via the following:
- Add a tenant to tenants table via supabase. (NOTE: the email must be accessible by you)
- Utilize an API testing tool (such as postman) to sign up by sending a POST request to `http://localhost:3000/auth/register` request body consisting of your email and password
EX:
```
{
    "email":"your_email_address@example.com",
    "password":"needs_to_be_more_than_6_characters"

}
```
(NOTE: header needs to consist of `Content-Type` as key and `application/json` as value)

- After registration, go to your email inbox, get to the confirmation email and click "confirm your mail" (NOTE: after clicking confirm your mail, you will get a GET request error messasge. That is fine, because we have yet to establish a route for it)
- To make sure you verified. In supabase, hover your mouse to the left-most pannel, and you should see `Table-Editor`, click on it. 
- click on users table
![image](https://github.com/user-attachments/assets/179bd911-0fc0-41d2-9af6-bc21e12f91ce)
- Looking at the row that is associated to your email, scroll to the column `email_confirmed_at`. If it is not `NULL`, this means that you are verified via email.
![image](https://github.com/user-attachments/assets/3a35d948-e0c0-425e-8deb-5ab54d5db014)

## How to test
- Hover over the left panel, and click on "authentication'
-  Under "Manage", click on "Users", and then scroll all the way to the right and look at "Last signed in at" column
![image](https://github.com/user-attachments/assets/98b1c309-d6ca-4755-871a-0bca99db5e3a)
- If you already confirmed your email, that will be considered as your first signed in time. Note down that time
- **(Test invalid input)** Submit a post request to `http://localhost:3000/auth/signin`, with INVALID credentials in your body to test for invalid input
-  Check the "Last signed in at" column, there shouldn't be a change compared to what you noted down.
- **(Test valid input)** Submit a post request to `http://localhost:3000/auth/signin`, with VALID credentials in your body.
-  Check the "Last signed in at" column, there should be a change compared to what you noted down.
 
