### PR TITLE
Es 36 login api endpoint - 2

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -57,13 +57,12 @@ router.post('/signin', async (req: Request, res: Response) => {
             return;
         }
 
-        const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
-
+        // access token expires_in by default is 3600 seconds, * 1000 = 3600000 milliseconds = 1 hour
         res.cookie('sb-access-token', session.access_token, {
             httpOnly: true, //Prevents JS access
             // secure: true, // only sent over HTTPS, set as true only in production
             sameSite: 'strict',
-            maxAge: session.expires_in * thirtyDaysInSeconds,
+            maxAge: session.expires_in * 1000,
 
         })
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -50,10 +50,25 @@ router.post('/signin', async (req: Request, res: Response) => {
             return 
         }
 
-        if (data) {
-            res.status(200).json({ message: 'Signed in successfully', user: data });
+        // Set session cookie (for persistence)
+        const {session} = data;
+        if (!session) {
+            res.status(500).json({message: "failed to retrieve session."});
             return;
         }
+
+        const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
+
+        res.cookie('sb-access-token', session.access_token, {
+            httpOnly: true, //Prevents JS access
+            // secure: true, // only sent over HTTPS, set as true only in production
+            sameSite: 'strict',
+            maxAge: session.expires_in * thirtyDaysInSeconds,
+
+        })
+
+        res.status(200).json({ message: 'Signed in successfully'});
+        return;
 
     } catch (error) {
         res.status(500).json({message: 'Server error'});


### PR DESCRIPTION
## Description
- Introduced cookie issuance during sign in

## How to test
- Submit a POST request to `http://localhost:3000/auth/signin`, you should see Cookies from the response that consist of `sb-access-token`