### PR TITLE
ES-38 Allow frontend to communicate with backend API

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "license": "ISC",
   "dependencies": {
     "@supabase/supabase-js": "^2.49.1",
+    "@types/cors": "^2.8.17",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.39.3",
     "express": "^4.21.2",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import express, { application } from 'express';
 import config from "./config/config";
 import morgan from 'morgan'; // Http request logger, help debug
+import cors from 'cors';
 
 // Import routes
 import authRoutes from "./routes/auth";
@@ -12,6 +13,9 @@ const PORT: number = config.PORT;
 
 app.use(express.json());
 app.use(morgan("common"));
+
+// Allows request from frontend
+app.use(cors({origin: "http://localhost:5173"}));
 
 // Use routes
 app.use('/auth', authRoutes);


### PR DESCRIPTION
### Description:
Introduce CORS tool to allow frontend send requests to backend.

### How to test:
- Pull this to your local branch, spin up frontend in one terminal and backend in the other.
- From the frontend, the followings are some testable routes to make a request to: (NOTE: only existing tenants are registerable. Feel free to add another tenant for testing purpose)
  -  `http://localhost:3000/auth/register` POST request
  -  `http://localhost:3000/auth/signin` POST request


