### PR TITLE
ES-81: Add routes to handle lease view and signing

### DIFF
--- a/src/authClient/index.ts
+++ b/src/authClient/index.ts
@@ -1,3 +1,6 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 import { createClient } from '@supabase/supabase-js';
 import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
 import { Request, Response } from 'express';

--- a/src/db/models/lease.ts
+++ b/src/db/models/lease.ts
@@ -77,3 +77,13 @@ export const deleteLease = async (leaseId: string) => {
         return { success: false };
     }
 };
+
+export const updateLease = async (leaseId: string, lease: Partial<LeaseInsertType>) => {
+    try {
+        const result = await db.update(leases).set(lease).where(eq(leases.id, leaseId)).returning();
+        return result[0];
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
+};

--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -20,6 +20,34 @@ export const getTenantById = async (tenantId: string) => {
     }
 };
 
+export const getTenantByUserId = async (userId: string) => {
+    try {
+        const result = await db.query.tenants.findFirst({
+            where: eq(tenants.userId, userId),
+            columns: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                email: true,
+            },
+            with: {
+                unitTenants: {
+                    columns: {
+                        id: true,
+                    },
+                    with: {
+                        leases: true
+                    }
+                }
+            }
+        });
+        return result;
+
+    } catch (error) {
+        return null;
+    }
+};
+
 export const getTenantByEmail = async (tenantEmail: string) => {
     try {
         const result = await db.select().from(tenants).where(eq(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,8 +57,7 @@ export const tenants = pgTable('tenants', {
     dob: date('dob'),
     email: varchar('email', { length: 255 }).notNull().unique(),
     phone: text('phone'),
-    user_id: uuid('user_id'),
-    passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+    userId: uuid('user_id'),
     ...timestamps
 });
 
@@ -81,6 +80,7 @@ export const leases = pgTable('leases', {
     monthlyRate: decimal('monthly_rate', { precision: 10, scale: 2 }).notNull(),
     document: text('document'),
     status: text('status').notNull(),
+    signature: boolean('signature').default(false),
     signedAt: timestamp('signed_at', { withTimezone: true, mode: 'date' }),
     ...timestamps
 });
@@ -214,6 +214,13 @@ export const unitTenantsRelations = relations(unitTenants, ({ one, many }) => ({
         references: [units.id],
     }),
     leases: many(leases),
+}));
+
+export const leasesRelations = relations(leases, ({ one }) => ({
+    unitTenant: one(unitTenants, {
+        fields: [leases.unitTenantsId],
+        references: [unitTenants.id],
+    }),
 }));
 
 export const maintenanceRequestsRelations = relations(maintenanceRequests, ({ one }) => ({

--- a/src/routes/leases.ts
+++ b/src/routes/leases.ts
@@ -1,0 +1,42 @@
+import express, { Request, Response } from 'express';
+import { getTenantByUserId } from '../db/models/tenant';
+import { updateLease } from '../db/models/lease';
+
+const router = express.Router();
+
+router.get('/view', async (req: Request, res: Response) => {
+    const userId = req.user.userId;
+    const tenant = await getTenantByUserId(userId);
+
+    if (!tenant) {
+        res.status(404).json({ message: 'Tenant not found' });
+        return;
+    };
+
+    const leases = tenant.unitTenants[0].leases;
+    const renewalLease = leases.filter(lease => {
+        return lease.status === 'pending';
+    });
+
+    if (!renewalLease.length) {
+        res.status(404).json({ message: 'No pending renewals.' });
+        return;
+    }
+    res.status(200).json(renewalLease);
+    return;
+});
+
+router.post('/sign', async (req: Request, res: Response) => {
+    const leaseId = req.body.leaseId;
+    const lease = await updateLease(leaseId, { status: 'active', signature: true, signedAt: new Date() });
+
+    if (!lease) {
+        res.status(404).json({ message: 'Lease not found' });
+        return;
+    };
+
+    res.status(200).json({ message: 'Lease signed successfully.' });
+    return;
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,13 @@
-import express, {Request, Response} from 'express';
+import express, { Request, Response } from 'express';
 import cookieParser from 'cookie-parser';
 import config from "./config/config";
 import morgan from 'morgan'; // Http request logger, help debug
 import cors from 'cors';
+import { requiresAuthentication } from './middleware/authMiddleware';
 
 // Import routes
 import authRoutes from "./routes/auth";
+import leaseRoutes from "./routes/leases";
 
 // Configuration
 const app = express();
@@ -16,9 +18,9 @@ const PORT: number = config.PORT;
 // Ex: req.user will have info from users table, NOT from tenants table.
 declare module "express-serve-static-core" {
     interface Request {
-      user?: any;
+        user?: any;
     }
-  }
+}
 
 app.use(express.json());
 app.use(morgan("common"));
@@ -29,6 +31,7 @@ app.use(cors({origin: "http://localhost:5173"}));
 
 // Use routes
 app.use('/auth', authRoutes);
+app.use('/leases', requiresAuthentication, leaseRoutes);
 
 // Listener
 app.listen(PORT, HOST, () => {


### PR DESCRIPTION
## Description

This work adds two routes `/leases/view` and `/leases/sign`, which will handle retrieving a tenant's pending lease (renewal) and update lease to signed once tenant has completed the proper action on frontend.

This PR also includes an update to the database schema to support the lease signing logic.

## How to test:
### Data needed to test endpoints
- test user email and password: `email: kwame.osei@yopmail.com` `password: kwameosei`
- `sb-access-token`

1. ensure that the values for the user lease in the database are set to the following:
**database table: leases** [link to table filtered to lease for test user](https://supabase.com/dashboard/project/qkzpubjaxiuyetdvwnzp/editor/29360?schema=public&filter=id:eq:a9652b37-a540-4972-bbc3-109ede00b7df)
**status**: `pending`
**signed_at**: NULL
**signature**: `false`

*these values simulate the state that a renewal lease should be in prior to a user signing or terminating lease*

**Get `sb-access-token`**
- using the test user info from about, call  the `/auth/signin` endpoint to retrieve the access token, which should be logged in the server after successfully making API call. Once this is retrieved, proceed to first step of testing endpoint.

### Test `/leases/view`
1. Add `sb-access-token` from previous step to header of request as cookie
2. Call endpoint with GET method - this endpoint returns the pending renewal lease associated with the user
3. Copy the id value from this response. This will be used for the `leaseId` to test the next endpoint.

example response:
![response_example@2x](https://github.com/user-attachments/assets/3da624ae-5a95-4888-974c-634213bb8b8d)

error response  if no pending lease found:
![CleanShot 2025-03-14 at 06 05 29@2x](https://github.com/user-attachments/assets/598701fc-5bd0-4eec-8a56-19ab31bef25e)

### Test `/leases/sign`
1. Ensure that same access token is still included in header as cookie
2. Add id from previous test as body param: `{ "leaseId": "a9652b37-a540-4972-bbc3-109ede00b7df"
3. Call endpoint with POST method

example response:
![CleanShot 2025-03-14 at 06 04 53@2x](https://github.com/user-attachments/assets/9deb892e-ee0e-41ad-958b-8898ebda6fc5)

