### PR TITLE
ES-82 smart package backend

### DIFF
--- a/src/db/models/packages.ts
+++ b/src/db/models/packages.ts
@@ -1,5 +1,5 @@
 import { db } from '../index';
-import { eq, and, asc } from 'drizzle-orm';
+import { eq, and, asc, sql } from 'drizzle-orm';
 import { packages, PackageInsertType, PackageStatus } from '../schema';
 
 export const createPackage = async (packageDetails: PackageInsertType) => {
@@ -26,10 +26,12 @@ export const getPackagesByTenantId = async (tenantId: string) => {
     try {
         const result = await db.query.packages.findMany({
             where: and(
-                eq(packages.tenantId, tenantId),
-                eq(packages.status, 'delivered')
+                eq(packages.tenantId, tenantId)
             ),
-            orderBy: asc(packages.deliveryTime),
+            orderBy: [
+                sql`CASE WHEN ${packages.status} = 'delivered' THEN 0 ELSE 1 END ASC`,
+                asc(packages.deliveryTime)
+            ],
             with: {
                 smartLocker: {
                     columns: {

--- a/src/db/models/packages.ts
+++ b/src/db/models/packages.ts
@@ -60,3 +60,14 @@ export const updatePackageStatus = async (packageId: string, status: PackageStat
         return null;
     }
 };
+
+export const removeAllPackages = async () => {
+    try {
+        const result = await db.delete(packages);
+        return result; // Return the number of deleted rows (if applicable)
+    } catch (error) {
+        console.error("Error removing all packages:", error);
+        return null;
+    }
+};
+

--- a/src/db/models/packages.ts
+++ b/src/db/models/packages.ts
@@ -50,7 +50,7 @@ export const updatePackageStatus = async (packageId: string, status: PackageStat
     try {
         const result = await db
             .update(packages)
-            .set({ status }) // Ensures type safety from PackageStatus
+            .set({ status })
             .where(eq(packages.id, packageId))
             .returning();
 

--- a/src/db/models/packages.ts
+++ b/src/db/models/packages.ts
@@ -1,6 +1,6 @@
 import { db } from '../index';
-import { eq, and } from 'drizzle-orm';
-import { packages, PackageInsertType } from '../schema';
+import { eq, and, asc } from 'drizzle-orm';
+import { packages, PackageInsertType, PackageStatus } from '../schema';
 
 export const createPackage = async (packageDetails: PackageInsertType) => {
     try {
@@ -29,6 +29,7 @@ export const getPackagesByTenantId = async (tenantId: string) => {
                 eq(packages.tenantId, tenantId),
                 eq(packages.status, 'delivered')
             ),
+            orderBy: asc(packages.deliveryTime),
             with: {
                 smartLocker: {
                     columns: {
@@ -42,5 +43,20 @@ export const getPackagesByTenantId = async (tenantId: string) => {
     } catch (error) {
         console.error(error);
         return [];
+    }
+};
+
+export const updatePackageStatus = async (packageId: string, status: PackageStatus) => {
+    try {
+        const result = await db
+            .update(packages)
+            .set({ status }) // Ensures type safety from PackageStatus
+            .where(eq(packages.id, packageId))
+            .returning();
+
+        return result[0] || null;
+    } catch (error) {
+        console.error("Error updating package status:", error);
+        return null;
     }
 };

--- a/src/db/models/smartLocker.ts
+++ b/src/db/models/smartLocker.ts
@@ -68,3 +68,13 @@ export const deleteSmartLocker = async (id: string) => {
         return { success: false };
     }
 };
+
+export const resetAllSmartLockerStatus = async () => {
+    try {
+        const result = await db.update(smartLockers).set({ isOccupied: false });
+        return { success: true, updatedRows: result };
+    } catch (error) {
+        console.error("Error resetting smart locker statuses:", error);
+        return { success: false };
+    }
+};

--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -89,13 +89,13 @@ export const getTenantInfoByUserId = async (userId: string) => {
     try {
         const result = await db
             .select({
-                user_id: tenants.user_id,
+                userId: tenants.userId,
                 firstName: tenants.firstName,
                 lastName: tenants.lastName,
                 email: tenants.email,
             })
             .from(tenants)
-            .where(eq(tenants.user_id, userId));
+            .where(eq(tenants.userId, userId));
 
         return result[0]; // Returns the first result as an object.
     } catch (error) {

--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -84,3 +84,22 @@ export const deleteTenant = async (tenantId: string) => {
         return { success: false };
     }
 };
+
+export const getTenantInfoByUserId = async (userId: string) => {
+    try {
+        const result = await db
+            .select({
+                user_id: tenants.user_id,
+                firstName: tenants.firstName,
+                lastName: tenants.lastName,
+                email: tenants.email,
+            })
+            .from(tenants)
+            .where(eq(tenants.user_id, userId));
+
+        return result[0]; // Returns the first result as an object.
+    } catch (error) {
+        console.error(error); // Log the error for debugging.
+        return null;
+    }
+};

--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -89,7 +89,7 @@ export const getTenantInfoByUserId = async (userId: string) => {
     try {
         const result = await db
             .select({
-                userId: tenants.userId,
+                id: tenants.id, 
                 firstName: tenants.firstName,
                 lastName: tenants.lastName,
                 email: tenants.email,
@@ -97,9 +97,9 @@ export const getTenantInfoByUserId = async (userId: string) => {
             .from(tenants)
             .where(eq(tenants.userId, userId));
 
-        return result[0]; // Returns the first result as an object.
+        return result[0] ?? null;
     } catch (error) {
-        console.error(error); // Log the error for debugging.
+        console.error("Error fetching tenant info:", error); // More descriptive error log
         return null;
     }
 };

--- a/src/lib/seed/emulatePickUpOnePackage.ts
+++ b/src/lib/seed/emulatePickUpOnePackage.ts
@@ -1,0 +1,73 @@
+/*
+
+Description:
+- With the earlier delivered package on the top, that one will be
+used for demo purpose, pretending that we've picked up
+the package.
+
+1. query and get the earlier package from the tenant.
+(used email to get tenant id)
+
+2. use tenant id to get all his/her packages, in ascending order
+on date time, the earlest paackage will be on the top, LIMIT 1.
+(this will get the earliest delivered package's package id)
+
+3. with package id, use it to update package status as "retrieved"
+
+*/
+
+import { getTenantByEmail } from "../../db/models/tenant";
+import { getPackagesByTenantId, updatePackageStatus } from "../../db/models/packages";
+import {client} from "../../db/index";
+import dotenv from 'dotenv';
+dotenv.config();
+
+const getTenantIdViaEmail = async () => {
+    const email = process.env.EMAIL;
+    if (!email) {
+        console.error("EMAIL environment variable is not set");
+    } else {
+        const tenantInfo = await getTenantByEmail(email);
+        if (!tenantInfo) {
+            console.error("Not a valid tenant email");
+            return null;
+        } else {
+            return tenantInfo.id;
+        }
+        
+    }    
+}
+
+const main = async () => {
+    const email = process.env.EMAIL;
+    const tenantId = await getTenantIdViaEmail();
+
+    if (!tenantId) {
+        console.error("Non-existing tenant ID");
+        await client.end();
+        return;
+    } 
+
+    const packages = await getPackagesByTenantId(tenantId);
+
+    if (packages.length === 0) {
+        console.error("No existing package!");
+        await client.end();
+        return;
+    }
+
+    const STATUS = "retrieved";
+    const pickUpPackageId = packages[0].id;
+    const result = await updatePackageStatus(pickUpPackageId, STATUS);
+    if (!result) {
+        console.error("Unable to update package status");
+        await client.end();
+        return;
+    }
+
+    console.log("Package pickup status update complete!");
+    await client.end();
+};
+
+
+main();

--- a/src/lib/seed/emulatePickUpOnePackage.ts
+++ b/src/lib/seed/emulatePickUpOnePackage.ts
@@ -1,21 +1,3 @@
-/*
-
-Description:
-- With the earlier delivered package on the top, that one will be
-used for demo purpose, pretending that we've picked up
-the package.
-
-1. query and get the earlier package from the tenant.
-(used email to get tenant id)
-
-2. use tenant id to get all his/her packages, in ascending order
-on date time, the earlest paackage will be on the top, LIMIT 1.
-(this will get the earliest delivered package's package id)
-
-3. with package id, use it to update package status as "retrieved"
-
-*/
-
 import { getTenantByEmail } from "../../db/models/tenant";
 import { getPackagesByTenantId, updatePackageStatus } from "../../db/models/packages";
 import {updateSmartLockerStatus} from "../../db/models/smartLocker";

--- a/src/lib/seed/emulatePickUpOnePackage.ts
+++ b/src/lib/seed/emulatePickUpOnePackage.ts
@@ -18,6 +18,7 @@ on date time, the earlest paackage will be on the top, LIMIT 1.
 
 import { getTenantByEmail } from "../../db/models/tenant";
 import { getPackagesByTenantId, updatePackageStatus } from "../../db/models/packages";
+import {updateSmartLockerStatus} from "../../db/models/smartLocker";
 import {client} from "../../db/index";
 import dotenv from 'dotenv';
 dotenv.config();
@@ -58,14 +59,20 @@ const main = async () => {
 
     const STATUS = "retrieved";
     const pickUpPackageId = packages[0].id;
-    const result = await updatePackageStatus(pickUpPackageId, STATUS);
-    if (!result) {
+    const updatedPackage = await updatePackageStatus(pickUpPackageId, STATUS);
+    if (!updatedPackage) {
         console.error("Unable to update package status");
         await client.end();
         return;
     }
 
-    console.log("Package pickup status update complete!");
+    if (updatedPackage.lockerId) {
+        await updateSmartLockerStatus(updatedPackage.lockerId, false);
+        console.log("Package pickup status update complete!");
+    } else {
+        console.error("Unable to update locker status");
+    }
+    
     await client.end();
 };
 

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -27,8 +27,8 @@ const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: 
         await updateSmartLockerStatus(lockerId, true);
     }
 
-    const timeStampOne = new Date(); // Current date and time
     const timeStampTwo = new Date(); // Current date and time
+    const timeStampOne = new Date(); // Current date and time
     const timeStampThree = new Date(); // Current date and time
 
     // Subtract 5 hours
@@ -59,9 +59,9 @@ const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: 
         deliveryTime: timeStampThree 
     };
 
-    await createPackage(packageOneDetails);
-    await createPackage(packageTwoDetails);
     await createPackage(packageThreeDetails);
+    await createPackage(packageOneDetails);
+    await createPackage(packageTwoDetails);  
 };
 
 

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -22,19 +22,22 @@ const getTenantIdViaEmail = async () => {
     }    
 }
 
-const createTwoSeedPackages = async (twoAvailableLockers: string[], tenantId: string) => {
-    for (let lockerId of twoAvailableLockers) {
+const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: string) => {
+    for (let lockerId of threeAvailableLockers) {
         await updateSmartLockerStatus(lockerId, true);
     }
 
     const timeStampOne = new Date(); // Current date and time
     const timeStampTwo = new Date(); // Current date and time
+    const timeStampThree = new Date(); // Current date and time
+
     // Subtract 5 hours
     timeStampOne.setHours(timeStampOne.getHours() - 5);
+    timeStampThree.setHours(timeStampThree.getHours() - 10);
     
     const packageOneDetails = {
         tenantId: tenantId,
-        lockerId: twoAvailableLockers[0],
+        lockerId: threeAvailableLockers[0],
         lockerCode: '8e3K9s',
         status: 'delivered' as 'delivered' | 'retrieved',
         deliveryTime: timeStampOne 
@@ -42,14 +45,23 @@ const createTwoSeedPackages = async (twoAvailableLockers: string[], tenantId: st
 
     const packageTwoDetails = {
         tenantId: tenantId,
-        lockerId: twoAvailableLockers[1],
+        lockerId: threeAvailableLockers[1],
         lockerCode: '0zk238',
         status: 'delivered' as 'delivered' | 'retrieved',
         deliveryTime: timeStampTwo 
     };
 
+    const packageThreeDetails = {
+        tenantId: tenantId,
+        lockerId: threeAvailableLockers[2],
+        lockerCode: 'ys3ldZ',
+        status: 'retrieved' as 'delivered' | 'retrieved',
+        deliveryTime: timeStampThree 
+    };
+
     await createPackage(packageOneDetails);
     await createPackage(packageTwoDetails);
+    await createPackage(packageThreeDetails);
 };
 
 
@@ -66,9 +78,8 @@ const main = async () => {
             console.log("Less than 2 lockers left, unable to create seed data for 2 packages");
         } else {
         
-            const twoAvailableLockers = [availableLockers[0].id, availableLockers[1].id]
-            console.log(twoAvailableLockers);
-            await createTwoSeedPackages(twoAvailableLockers, tenantId);
+            const threeAvailableLockers = [availableLockers[0].id, availableLockers[1].id, availableLockers[2].id]
+            await createTwoSeedPackages(threeAvailableLockers, tenantId);
         }
         
     }

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -49,10 +49,7 @@ const createTwoSeedPackages = async (twoAvailableLockers: string[], tenantId: st
     };
 
     await createPackage(packageOneDetails);
-    
-    
-    // await createPackage();
-    // await createPackage();
+    await createPackage(packageTwoDetails);
 };
 
 

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -1,0 +1,83 @@
+import {client} from "../../db/index";
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { getTenantByEmail } from "../../db/models/tenant";
+import {getAllOpenSmartLockers, updateSmartLockerStatus} from "../../db/models/smartLocker";
+import {createPackage} from "../../db/models/packages";
+
+const getTenantIdViaEmail = async () => {
+    const email = process.env.EMAIL;
+    if (!email) {
+        console.error("EMAIL environment variable is not set");
+    } else {
+        const tenantInfo = await getTenantByEmail(email);
+        if (!tenantInfo) {
+            console.error("Not a valid tenant email");
+            return null;
+        } else {
+            return tenantInfo.id;
+        }
+        
+    }    
+}
+
+const createTwoSeedPackages = async (twoAvailableLockers: string[], tenantId: string) => {
+    for (let lockerId of twoAvailableLockers) {
+        await updateSmartLockerStatus(lockerId, true);
+    }
+
+    const timeStampOne = new Date(); // Current date and time
+    const timeStampTwo = new Date(); // Current date and time
+    // Subtract 5 hours
+    timeStampOne.setHours(timeStampOne.getHours() - 5);
+    
+    const packageOneDetails = {
+        tenantId: tenantId,
+        lockerId: twoAvailableLockers[0],
+        lockerCode: '8e3K9s',
+        status: 'delivered' as 'delivered' | 'retrieved',
+        deliveryTime: timeStampOne 
+    };
+
+    const packageTwoDetails = {
+        tenantId: tenantId,
+        lockerId: twoAvailableLockers[1],
+        lockerCode: '0zk238',
+        status: 'delivered' as 'delivered' | 'retrieved',
+        deliveryTime: timeStampTwo 
+    };
+
+    await createPackage(packageOneDetails);
+    
+    
+    // await createPackage();
+    // await createPackage();
+};
+
+
+const main = async () => {
+    const email = process.env.EMAIL;
+
+    const tenantId = await getTenantIdViaEmail();
+    if (!tenantId) {
+        console.error("None-existing tenant id");
+    } else {
+        // console.log(tenantId);
+        let availableLockers = await getAllOpenSmartLockers();
+        if (availableLockers.length < 2) {
+            console.log("Less than 2 lockers left, unable to create seed data for 2 packages");
+        } else {
+        
+            const twoAvailableLockers = [availableLockers[0].id, availableLockers[1].id]
+            console.log(twoAvailableLockers);
+            await createTwoSeedPackages(twoAvailableLockers, tenantId);
+        }
+        
+    }
+
+
+    await client.end();
+}
+
+main();

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -39,7 +39,7 @@ const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: 
         tenantId: tenantId,
         lockerId: threeAvailableLockers[0],
         lockerCode: '8e3K9s',
-        status: 'delivered' as 'delivered' | 'retrieved',
+        status: 'retrieved' as 'delivered' | 'retrieved',
         deliveryTime: timeStampOne 
     };
 
@@ -55,7 +55,7 @@ const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: 
         tenantId: tenantId,
         lockerId: threeAvailableLockers[2],
         lockerCode: 'ys3ldZ',
-        status: 'retrieved' as 'delivered' | 'retrieved',
+        status: 'delivered' as 'delivered' | 'retrieved',
         deliveryTime: timeStampThree 
     };
 

--- a/src/lib/seed/returnToPreSeedState.ts
+++ b/src/lib/seed/returnToPreSeedState.ts
@@ -1,0 +1,20 @@
+/*
+APPROACH:
+1. Delete all packages in packages table
+2. Set all locker is_occupied as false
+*/
+
+
+
+import { removeAllPackages } from "../../db/models/packages";
+import {updateSmartLockerStatus} from "../../db/models/smartLocker";
+import {client} from "../../db/index";
+
+const main = async () => {
+    await removeAllPackages();
+    console.log("Delete all pacakges operation complete!");
+    await client.end();
+};
+
+
+main();

--- a/src/lib/seed/returnToPreSeedState.ts
+++ b/src/lib/seed/returnToPreSeedState.ts
@@ -7,12 +7,14 @@ APPROACH:
 
 
 import { removeAllPackages } from "../../db/models/packages";
-import {updateSmartLockerStatus} from "../../db/models/smartLocker";
+import {resetAllSmartLockerStatus} from "../../db/models/smartLocker";
 import {client} from "../../db/index";
 
 const main = async () => {
     await removeAllPackages();
     console.log("Delete all pacakges operation complete!");
+    await resetAllSmartLockerStatus();
+    console.log("Reset all locker as not occupied");
     await client.end();
 };
 

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import {authClient} from '../authClient';
+import { getTenantInfoByUserId } from '../db/models/tenant'
 
 export const requiresAuthentication =  async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -21,6 +22,20 @@ export const requiresAuthentication =  async (req: Request, res: Response, next:
             userId: data.user.id, 
             email: data.user.email
         };
+
+        const tenantInfo = await getTenantInfoByUserId(data.user.id);
+        if (!tenantInfo) {
+            res.status(401).json({message: "unable to find tenant in query"});
+            return;          
+        }
+
+        req.tenant = {
+            id: tenantInfo.id,       
+            firstName: tenantInfo.firstName, 
+            lastName: tenantInfo.lastName,   
+            email: tenantInfo.email          
+        };
+
         next();
     } catch (err) {
         console.error('Auth middleware error:', err)        

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -1,0 +1,5 @@
+import express, { Request, Response } from 'express';
+
+const router = express.Router();
+
+export default router;

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -4,9 +4,7 @@ import { getPackagesByTenantId } from '../db/models/packages'
 import { getTenantInfoByUserId } from '../db/models/tenant'
 const router = express.Router();
 
-router.get('/', 
-    requiresAuthentication,
-    async (req: Request, res: Response) => {
+router.get('/', async (req: Request, res: Response) => {
         try {
             const authUserId = req.user.userId;
             //NOTE: wont be getting tenantId if i introduce it to middleware

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -1,7 +1,5 @@
 import express, { Request, Response } from 'express';
-import { requiresAuthentication } from '../middleware/authMiddleware';
-import { getPackagesByTenantId } from '../db/models/packages'
-import { getTenantInfoByUserId } from '../db/models/tenant'
+import { getPackagesByTenantId, getPackageById } from '../db/models/packages'
 const router = express.Router();
 
 export interface Package {
@@ -36,6 +34,22 @@ router.get('/', async (req: Request, res: Response) => {
             res.status(500).json({ message: 'Server error' });
             return;
         }
+});
+
+router.get('/:packageId', async (req: Request, res: Response) => {
+    const packageId = req.params.packageId;
+    try {
+        const returnedPackage = await getPackageById(packageId);
+        if (!returnedPackage || !returnedPackage.lockerCode) {
+            res.status(400).json({message: "Invalid package id"});
+            return;
+        }
+
+        res.status(200).json({code: returnedPackage.lockerCode});
+    } catch (error) {
+        res.status(500).json({ message: 'Server error' });
+        return;
+    }
 });
 
 export default router;

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -1,5 +1,29 @@
 import express, { Request, Response } from 'express';
-
+import { requiresAuthentication } from '../middleware/authMiddleware';
+import { getPackagesByTenantId } from '../db/models/packages'
 const router = express.Router();
+
+router.get('/', 
+    requiresAuthentication,
+    async (req: Request, res: Response) => {
+        try {
+            const authUserId = req.user.userId;
+            // const result = await getPackagesByTenantId(authUserId);
+            // console.log(authUserId);
+            res.send("CHECK POINT 1, non-functional smartPackage endpoint");
+        } catch (error) {
+
+        }
+    // const { data, error } = await updatePassword(req, res);
+
+    // if (error) {
+    //     console.log(error);
+    //     res.status(400).json({ message: 'Not authorized. Unable to reset password.' });
+    //     return;
+    // }
+
+    // res.status(200).json({ message: 'Password reset successfully.' });
+    // return;
+});
 
 export default router;

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -6,17 +6,8 @@ const router = express.Router();
 
 router.get('/', async (req: Request, res: Response) => {
         try {
-            const authUserId = req.user.userId;
-            //NOTE: wont be getting tenantId if i introduce it to middleware
-            let result = await getTenantInfoByUserId(authUserId);
+            const result = await getPackagesByTenantId(req.tenant.id);
             console.log(result);
-            // const tenantId: string | null = await getTenantInfoByUserId(authUserId);
-            // if (!tenantId) {
-            //     res.status(200).json({message: "invalid tenant id"});
-            //     return;
-            // }
-            // const result = await getPackagesByTenantId(tenantId);
-            // console.log(result);
             res.send("CHECK POINT 1, non-functional smartPackage endpoint");
         } catch (error) {
             res.status(500).json({ message: 'Server error' });

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import { requiresAuthentication } from '../middleware/authMiddleware';
 import { getPackagesByTenantId } from '../db/models/packages'
+import { getTenantInfoByUserId } from '../db/models/tenant'
 const router = express.Router();
 
 router.get('/', 
@@ -8,22 +9,21 @@ router.get('/',
     async (req: Request, res: Response) => {
         try {
             const authUserId = req.user.userId;
-            // const result = await getPackagesByTenantId(authUserId);
-            // console.log(authUserId);
+            //NOTE: wont be getting tenantId if i introduce it to middleware
+            let result = await getTenantInfoByUserId(authUserId);
+            console.log(result);
+            // const tenantId: string | null = await getTenantInfoByUserId(authUserId);
+            // if (!tenantId) {
+            //     res.status(200).json({message: "invalid tenant id"});
+            //     return;
+            // }
+            // const result = await getPackagesByTenantId(tenantId);
+            // console.log(result);
             res.send("CHECK POINT 1, non-functional smartPackage endpoint");
         } catch (error) {
-
+            res.status(500).json({ message: 'Server error' });
+            return;
         }
-    // const { data, error } = await updatePassword(req, res);
-
-    // if (error) {
-    //     console.log(error);
-    //     res.status(400).json({ message: 'Not authorized. Unable to reset password.' });
-    //     return;
-    // }
-
-    // res.status(200).json({ message: 'Password reset successfully.' });
-    // return;
 });
 
 export default router;

--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -4,11 +4,34 @@ import { getPackagesByTenantId } from '../db/models/packages'
 import { getTenantInfoByUserId } from '../db/models/tenant'
 const router = express.Router();
 
+export interface Package {
+    id: string;
+    deliveredDateTime: Date | null;
+    status: 'delivered' | 'retrieved';
+}
+
+// PackagesResponse is now an array of Package objects
+export type PackagesResponse = Package[];
+
 router.get('/', async (req: Request, res: Response) => {
         try {
-            const result = await getPackagesByTenantId(req.tenant.id);
-            console.log(result);
-            res.send("CHECK POINT 1, non-functional smartPackage endpoint");
+            const packagesArr = await getPackagesByTenantId(req.tenant.id);
+            if (!packagesArr) {
+                console.error("Unable to properly retrieve packages info");
+                return;
+            }
+            //Front end needs to check the length of the array, if EQUAL 0, then show
+            // UI that reflects that
+
+            const responseData: PackagesResponse = packagesArr.map(individualpackage => {
+                return {
+                    id: individualpackage.id,
+                    deliveredDateTime: individualpackage.deliveryTime, 
+                    status: individualpackage.status as 'delivered' | 'retrieved'
+                };
+            });
+
+            res.status(200).json(responseData);
         } catch (error) {
             res.status(500).json({ message: 'Server error' });
             return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import authRoutes from "./routes/auth";
 import leaseRoutes from "./routes/leases";
 import { complaintRoutes } from "./routes/complaints";
 import accessCodesRoutes from "./routes/accessCodes";
+import smartPackgeRoutes from "./routes/smartPackage";
 
 // Configuration
 const app = express();
@@ -35,8 +36,8 @@ app.use(cors({ origin: "http://localhost:5173", credentials: true }));
 app.use("/auth", authRoutes);
 app.use("/leases", requiresAuthentication, leaseRoutes);
 app.use("/complaints", complaintRoutes);
-app.use("/leases", requiresAuthentication, leaseRoutes);
 app.use("/accessCodes", accessCodesRoutes);
+app.use('/smartpackage', smartPackgeRoutes);
 
 // Listener
 app.listen(PORT, HOST, () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,9 +19,11 @@ const PORT: number = config.PORT;
 
 // Allows us to set new property `user` for Request object throughout this project
 // Ex: req.user will have info from users table, NOT from tenants table.
+// Ex2: req.tenant will have info from tenants table.
 declare module "express-serve-static-core" {
   interface Request {
     user?: any;
+    tenant?: any;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ app.use("/auth", authRoutes);
 app.use("/leases", requiresAuthentication, leaseRoutes);
 app.use("/complaints", complaintRoutes);
 app.use("/accessCodes", accessCodesRoutes);
-app.use('/smartpackage', smartPackgeRoutes);
+app.use('/smartpackage', requiresAuthentication, smartPackgeRoutes);
 
 // Listener
 app.listen(PORT, HOST, () => {


### PR DESCRIPTION
### Description:
- Introduce backend smart package functionality
- Introduce middleware that allows protective route to have easy access to `req.tenant` (NOTE: This function piggy backs on this PR, it helps facilitate the smart package to work as intended)

### How to test:
- Spin up backend, run `npm i`
- Run a POST request to make sure that the tenant is signed in

#### Initial clean up
- On `EliteSpace-BackEnd` directory, run `npx ts-node ./src/lib/seed/returnToPreSeedState` to delete any existing packages, free up smart lockers
- Check supabase to make sure there aren't any existing packages in `packages` table, and all lockers' `is_occupied` status is `false`

#### Create seed data
- Go to your local `.env` add the following (this will allow use to establish seed data down the line)
`EMAIL=your-email@mail.com`
- (Create three packages) With your terminal in EliteSpace-BackEnd directory, run:  `npx ts-node ./src/lib/seed/generatePackages`
- Check supabase to see if the packages are there, and check to see if 3 lockers are occupied

#### Access package page:
- (This is what gets returned when user clicks on the package page) Make a GET request to `http://localhost:3000/smartpackage`, where you'll see JSON response having 3 packages info. You should see both status showing as `delivered`

#### Tenant clicks on the earliest delivered package to get its locker's access code
- Go to supabase, `packages` table, under the `delivery_time`, whichever package has an earlier `delivery_time`, copy that package's id.
![image](https://github.com/user-attachments/assets/dc6e5151-2520-43d7-bf5c-46dc1b097895)

- Submit a GET request to `http://localhost:3000/smartpackage/your-copied-package-id-here`, This will return the locker access code for that package.

#### Emulate tenant picking up the earliest delivered package:
- run `npx ts-node ./src/lib/seed/emulatePickUpOnePackage`

#### Tenant checks out packages page again, it should reflect the change, showing one of the package status as `retrieved`
- Submit a GET request to `http://localhost:3000/smartpackage`, and you should see it return package info that looks like:
one retrieved, one delivered.
![image](https://github.com/user-attachments/assets/8021b46c-9b9e-4311-bee6-9ba40032cafe)


#### Post test clean up
- run `npx ts-node ./src/lib/seed/returnToPreSeedState` to clean up what we just did.

