### PR TITLE
ES-121 adjust return value package pick up code access

### DIFF
--- a/src/routes/smartPackage.ts
+++ b/src/routes/smartPackage.ts
@@ -40,12 +40,28 @@ router.get('/:packageId', async (req: Request, res: Response) => {
     const packageId = req.params.packageId;
     try {
         const returnedPackage = await getPackageById(packageId);
-        if (!returnedPackage || !returnedPackage.lockerCode) {
+
+        if (!returnedPackage) {
+            res.status(400).json({message: "Invalid package object"});
+            return;
+        }
+
+        if (!returnedPackage.lockerCode) {
             res.status(400).json({message: "Invalid package id"});
             return;
         }
 
-        res.status(200).json({code: returnedPackage.lockerCode});
+        if (!returnedPackage.deliveryTime) {
+            res.status(400).json({message: "No delivery time"});
+            return;
+        }
+
+        const responseData = {
+            code: returnedPackage.lockerCode, 
+            deliveryTime: returnedPackage.deliveryTime
+        };
+
+        res.status(200).json(responseData);
     } catch (error) {
         res.status(500).json({ message: 'Server error' });
         return;


### PR DESCRIPTION
### Description:
When user clicks on a package to get its corresponding locker's access code, I'm also looking to return the `deliveryTime`

### How to test:
- Spin up back end
- Sign in via POST request with `http://localhost:3000/auth/signin` with proper credentials in the body
- Do clean up work by running: `npx ts-node ./src/lib/seed/returnToPreSeedState`
- Make sure the package table is empty
- Run `npx ts-node ./src/lib/seed/generatePackages`, to generate packages associated with your tenant.
- Pick a package and get its id:
![image](https://github.com/user-attachments/assets/72dbf524-78b9-46b4-a226-6d6aa2100352)
 - Submit a GET request to `http://localhost:3000/smartpackage/the-package-id-number`, you should see it return the locker access code and delivery date.
 - Clean up your test by running `npx ts-node ./src/lib/seed/returnToPreSeedState`