### PR TITLE
ES-94 Deploy backend on Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
+    "dev": "nodemon ./src/server.ts",
     "start": "ts-node ./src/server.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "db:generate": "npx drizzle-kit generate",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "start": "nodemon ./src/server.ts",
+    "start": "ts-node ./src/server.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "db:generate": "npx drizzle-kit generate",
     "db:migrate": "npx drizzle-kit migrate",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,6 @@
+import 'dotenv/config'
+
 export default {
-  HOST: "localhost",
-  PORT: 3000,
+  HOST: process.env.HOST || "localhost",
+  PORT: Number(process.env.PORT) || 3000,
 };


### PR DESCRIPTION
### Description:
- Adjusted development spin up command from `npm run start` to `npm run dev`
(Reason being that Render acts weird with nodemon, hence this change allows us to still be able to test things locally)
- Configuration of HOST and PORT to tailor towards what works on render, and also what works locally.
(Please put the following into your local `.env` file)
```
HOST=0.0.0.0
PORT=3000
```

### How to test:
- See if `npm run dev` works correctly locally
