### PR TITLE
ES-139 demo scripts for smart packages

### DIFF
--- a/src/db/models/tenant.ts
+++ b/src/db/models/tenant.ts
@@ -60,6 +60,7 @@ export const getTenantByEmail = async (tenantEmail: string) => {
 
         return result[0];
     } catch (error) {
+        console.error(error);
         throw new Error('Failed to fetch tenant by email');
     };
 };

--- a/src/lib/seed/emulatePickUpOnePackage.ts
+++ b/src/lib/seed/emulatePickUpOnePackage.ts
@@ -1,7 +1,7 @@
 import { getTenantByEmail } from "../../db/models/tenant";
 import { getPackagesByTenantId, updatePackageStatus } from "../../db/models/packages";
 import {updateSmartLockerStatus} from "../../db/models/smartLocker";
-import {client} from "../../db/index";
+// import {client} from "../../db/index";
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -26,7 +26,7 @@ export const retrievePackage = async () => {
 
     if (!tenantId) {
         console.error("Non-existing tenant ID");
-        await client.end();
+        // await client.end();
         return;
     } 
 
@@ -34,7 +34,7 @@ export const retrievePackage = async () => {
 
     if (packages.length === 0) {
         console.error("No existing package!");
-        await client.end();
+        // await client.end();
         return;
     }
 
@@ -43,7 +43,7 @@ export const retrievePackage = async () => {
     const updatedPackage = await updatePackageStatus(pickUpPackageId, STATUS);
     if (!updatedPackage) {
         console.error("Unable to update package status");
-        await client.end();
+        // await client.end();
         return;
     }
 
@@ -54,5 +54,5 @@ export const retrievePackage = async () => {
         console.error("Unable to update locker status");
     }
     
-    await client.end();
+    // await client.end();
 };

--- a/src/lib/seed/emulatePickUpOnePackage.ts
+++ b/src/lib/seed/emulatePickUpOnePackage.ts
@@ -21,8 +21,7 @@ const getTenantIdViaEmail = async () => {
     }    
 }
 
-const main = async () => {
-    const email = process.env.EMAIL;
+export const retrievePackage = async () => {
     const tenantId = await getTenantIdViaEmail();
 
     if (!tenantId) {
@@ -57,6 +56,3 @@ const main = async () => {
     
     await client.end();
 };
-
-
-main();

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -47,7 +47,7 @@ const createThreeSeedPackages = async (threeAvailableLockers: string[], tenantId
         tenantId: tenantId,
         lockerId: threeAvailableLockers[1],
         lockerCode: '0zk238',
-        status: 'delivered' as 'delivered' | 'retrieved',
+        status: 'retrieved' as 'delivered' | 'retrieved',
         deliveryTime: timeStampTwo 
     };
 
@@ -84,5 +84,5 @@ export const createPackages = async () => {
     }
 
 
-    await client.end();
+    // await client.end();
 }

--- a/src/lib/seed/generatePackages.ts
+++ b/src/lib/seed/generatePackages.ts
@@ -22,7 +22,7 @@ const getTenantIdViaEmail = async () => {
     }    
 }
 
-const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: string) => {
+const createThreeSeedPackages = async (threeAvailableLockers: string[], tenantId: string) => {
     for (let lockerId of threeAvailableLockers) {
         await updateSmartLockerStatus(lockerId, true);
     }
@@ -65,21 +65,20 @@ const createTwoSeedPackages = async (threeAvailableLockers: string[], tenantId: 
 };
 
 
-const main = async () => {
-    const email = process.env.EMAIL;
-
+export const createPackages = async () => {
     const tenantId = await getTenantIdViaEmail();
     if (!tenantId) {
         console.error("None-existing tenant id");
     } else {
         // console.log(tenantId);
         let availableLockers = await getAllOpenSmartLockers();
-        if (availableLockers.length < 2) {
-            console.log("Less than 2 lockers left, unable to create seed data for 2 packages");
-        } else {
-        
+        const EXISTING_LOCKER_AMT = 5;
+        if (availableLockers.length !== EXISTING_LOCKER_AMT) {
+            console.log("There are lockers occupied, not going to generate packages");
+        } else {    
             const threeAvailableLockers = [availableLockers[0].id, availableLockers[1].id, availableLockers[2].id]
-            await createTwoSeedPackages(threeAvailableLockers, tenantId);
+            await createThreeSeedPackages(threeAvailableLockers, tenantId);
+            console.log("Three packages, creation complete!!");
         }
         
     }
@@ -87,5 +86,3 @@ const main = async () => {
 
     await client.end();
 }
-
-main();

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1,0 +1,37 @@
+import express, { Request, Response } from 'express';
+import {createPackages} from "../lib/seed/generatePackages";
+import {retrievePackage} from "../lib/seed/emulatePickUpOnePackage";
+
+const router = express.Router();
+
+router.post('/createPackages', async (req: Request, res: Response) => {
+        try {
+            console.log("Action received, package creation logic invoked....");
+            // If no existing packages, generate 3 packages
+            // If there are existing packages, do nothing
+            await createPackages();
+
+            // 204 (No content), end b/c no response is needed.
+            res.status(204).end();
+        } catch (error) {
+            console.error("Error package generation: ", error);
+            res.status(500).json({ message: 'Server error' });
+            return;
+        }
+});
+
+router.post('/retrieveEarliestPackage', async (req: Request, res: Response) => {
+    try {
+        console.log("Package retrieve action received....");
+
+        await retrievePackage();
+
+        res.status(204).end();
+    } catch (error) {
+        console.error("Retrieved error: ", error);
+        res.status(500).json({ message: 'Server error' });
+        return;
+    }
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { complaintRoutes } from "./routes/complaints";
 import parkingRoutes from "./routes/parking";
 import accessCodesRoutes from "./routes/accessCodes";
 import smartPackageRoutes from "./routes/smartPackage";
+import demoRoutes from "./routes/demo";
 
 
 // Configuration
@@ -47,6 +48,7 @@ app.use("/parking", requiresAuthentication, parkingRoutes);
 app.use("/complaints", complaintRoutes);
 app.use("/accessCodes", accessCodesRoutes);
 app.use('/smartpackage', requiresAuthentication, smartPackageRoutes);
+app.use("/demo", demoRoutes);
 
 // Listener
 app.listen(PORT, HOST, () => {


### PR DESCRIPTION
### description
Established scripts for smart packages demo

demo user's test email in .env:
ex:
`EMAIL=demo-user-email@mail.com`
This is a 2-step process:
1. When tenant goes to the `/smartPackages` route, there won't be any packages to show.
However, when the `/smarPackges` gets rendered to the user, it executes a script which prompts the
frontend to make a request to the backend's `/demo/createPackages` endpoint. Hence 3 packages are created (1 delivered but not yet retrieved, 2 delivered and retrieved)

2. When tenant clicks on the only package that is available for pickup, the individual package page renders, user is able to see the info. In the background a script is executed at the same time which prompts frontend to send a request to the backend `/demo/retrieveEarliestPackage`, this will change the status of this package into "retrieved`. So when user click returns to the previous page, it should be able to reflect all packages have been picked up.

### How to test

#### Spin up dormant PR deployment preview
- Create a new table type the following in your browser's search bar `https://elitespace-backend-pr-29.onrender.com/`, this will take 2 ~ 3 minutes to spin up. (while waiting for it to spin up, do the following steps)

#### Set local env (During our demo, we will need to set the demo person's tenant email)
- `EMAIL=your-tenant-email@mail.com`

#### Clean up:
- run `npx ts-node ./src/lib/seed/returnToPreSeedState` locally to empty packages table.

#### Maybe wait around
- Once you are done with the clean up work, if `https://elitespace-backend-pr-29.onrender.com/` still shows application loading, then go do some other chores until it shows the following on the page
![image](https://github.com/user-attachments/assets/90af6107-2b7b-4bb7-9bca-8884228c8722)
If you see this message, this means that the preview deployment has spun up and is ready to receive our test requests.


#### Create Packages
- Use API tool make POST request to `https://elitespace-backend-pr-29.onrender.com//demo/createPackages` 
- This will create 3 packages for your logged-in tenant, 2 packages with `retrieved` status, 1 that has yet to be retrieved.
Check `packages` to see if that is the case.

#### Emulate picking up a package
- make a Post request to  `https://elitespace-backend-pr-29.onrender.com//demo/retrieveEarliestPackage`. 
- Check packages Table, you should see the 1 package that had `delivered` status as `retrieved` now.

#### clean up
run `npx ts-node ./src/lib/seed/returnToPreSeedState` locally to empty packages table.

