### PR TITLE
ES-137 feat(supabase-email-config): enhance email experience

### DIFF
--- a/src/authClient/authFunctions.ts
+++ b/src/authClient/authFunctions.ts
@@ -2,6 +2,8 @@ import { Request, Response } from "express";
 import { EmailOtpType } from "@supabase/supabase-js";
 import { authClient, newServerClient } from ".";
 
+const redirectURL = process.env.EMAIL_REDIRECT_URL;
+
 interface VerifyOtpParams {
   type: EmailOtpType;
   token_hash: string;
@@ -9,14 +11,14 @@ interface VerifyOtpParams {
   res: Response;
 }
 
-export async function signUpNewUser(email: string, password: string) {
-  const redirectURL = process.env.EMAIL_REDIRECT_URL;
+export async function signUpNewUser(email: string, password: string, userData: {first_name: string}) {
 
   const { data, error } = await authClient.auth.signUp({
     email: email,
     password: password,
     options: {
-      emailRedirectTo: redirectURL,
+      emailRedirectTo: `${redirectURL}?next=https://elitespace.netlify.app/login`,
+      data: userData, // passes first_name into Supabase .Data to be used in email configuration
     },
   });
 
@@ -39,7 +41,9 @@ export async function linkUserToTenant(email: string, authUserId: string, phone:
 }
 
 export async function initiatePasswordReset(email: string) {
-  const { data, error } = await authClient.auth.resetPasswordForEmail(email);
+  const { data, error } = await authClient.auth.resetPasswordForEmail(email, {
+    redirectTo: `${redirectURL}?next=https://elitespace.netlify.app/update-password`
+});
 
   return { data, error };
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.post("/register", async (req: Request, res: Response) => {
   try {
-    const { email, password, phone, dob } = req.body;
+    const { email, password, phone, dob, first_name } = req.body;
     const isExistingTenant = await getTenantByEmail(email);
 
     if (!isExistingTenant) {
@@ -16,7 +16,7 @@ router.post("/register", async (req: Request, res: Response) => {
       return;
     }
 
-    const { data, error } = await signUpNewUser(email, password);
+    const { data, error } = await signUpNewUser(email, password, first_name);
 
     if (error) {
       const errorMsg = error.code === "weak_password" ? "Password not strong enough. Must be atleast 6 characters." : "Error signing up";


### PR DESCRIPTION
### Jira ticket
[ES-137](https://jasminepvodev-1739842146260.atlassian.net/browse/ES-137?atlOrigin=eyJpIjoiMzk1NzE2MTNmZDEzNGVmZWJlZWY5ODQwNGEyZTViMzQiLCJwIjoiaiJ9) - Enhance email experience for confirm signup and reset password'

### Description
Here is the updated email for "confirm sign up":
<img width="995" alt="Screenshot 2025-03-22 at 9 24 52 PM" src="https://github.com/user-attachments/assets/1cb13f5c-6bc5-489a-8f29-9a1b371faedc" /> 
Here is the updated email for "reset password":
<img width="910" alt="Screenshot 2025-03-23 at 3 03 45 PM" src="https://github.com/user-attachments/assets/b7d8a68c-28ef-4606-b708-b5afb331a9e8" />

In order to use {.Data}, I had to add the options to read [user metadata](https://supabase.com/docs/reference/javascript/auth-api#:~:text=%2C%20anon_key-,Create%20a%20new%20user,-Creates%20a%20new) to use in the [email template](https://supabase.com/docs/guides/auth/auth-email-templates)

Also added 
- emailRedirectTo url for email confirmation
- [redirectTo](https://supabase.com/docs/guides/auth/redirect-urls) url for reset password

Also updated the url configurations with deployed urls for both frontend and backend - [view in Supabase
](https://supabase.com/dashboard/project/qkzpubjaxiuyetdvwnzp/auth/url-configuration)
<img width="995" alt="Screenshot 2025-03-22 at 9 12 37 PM" src="https://github.com/user-attachments/assets/a8c6366b-5ff2-4051-816b-ed89fe1d8ef6" />

### How to Test locally (prod test won't work until this is merged in and env is added to render)
1. Go to login page `http://localhost:5173/login`
2. Click on "Forgot your password?", which redirects to `http://localhost:5173/password-reset`
3. Enter your email
4. Check your email for reset password and click on the button
5. It will redirect you to `http://elitespace.netlify.app/password-reset`
6. Correct the url to local host `http://localhost:5173/update-password`
7. Change your password to a new password you have not used before
8. Log in to confirm the new password worked

### Note to @CloudsProgram 
Add the env variable to render 
`EMAIL_REDIRECT_URL=https://elitespace-backend-development.onrender.com/auth/confirm`

[ES-137]: https://jasminepvodev-1739842146260.atlassian.net/browse/ES-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ