### PR TITLE
ES-117 add handling for unconfirmed user

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -100,6 +100,11 @@ router.post("/signin", async (req: Request, res: Response) => {
     const { data, error } = await signInWithEmail(email, password);
 
     if (error) {
+      if (error.code === "email_not_confirmed") {
+        res.status(400).json({ message: "Check email and verify account to log in." });
+        return;
+      }
+
       res.status(401).json({ message: "Invalid email or password. Please try again." });
       return;
     }


### PR DESCRIPTION
## Issue
When a user attempts to login before confirming email, we are returning an error that reads "Invalid email or password. Please try again." which is misleading.

## Fix
Adding a check specifically for `email_not_confirmed` login error, so that a more specific error message is returned to the frontend for better handling and call to action for user.
