### PR TITLE
ES-142 Display tenant first name in confirmation email

### DIFF
--- a/src/authClient/authFunctions.ts
+++ b/src/authClient/authFunctions.ts
@@ -11,14 +11,18 @@ interface VerifyOtpParams {
   res: Response;
 }
 
-export async function signUpNewUser(email: string, password: string, userData: {first_name: string}) {
+export async function signUpNewUser(email: string, password: string, first_name: string) {
 
   const { data, error } = await authClient.auth.signUp({
     email: email,
     password: password,
     options: {
       emailRedirectTo: `${redirectURL}?next=https://elitespace.netlify.app/login`,
-      data: userData, // passes first_name into Supabase .Data to be used in email configuration
+      data: {
+        user_metadata: {
+          first_name
+        }
+      }, // passes first_name into Supabase .Data to be used in email configuration
     },
   });
 


### PR DESCRIPTION
### Description
This Made fixes address the issue where confirmation email doesn't show the user's first name.

FROM
![image](https://github.com/user-attachments/assets/36b11d53-f53e-4aab-88f1-e05784b55ddf)
To
![image](https://github.com/user-attachments/assets/699ad699-a938-44e2-a606-f9d44e82e1b2)

### How to test
- Spin up locally with `npm run dev`
EITHER:
- Create a new tenant, register and see the confirmation email
OR
- If you don't want to create a new row in tenants table, then you can use your existing tenant, go delete that tenant's authentication
![image](https://github.com/user-attachments/assets/e831b05a-33b2-4694-bee5-896c03ed53a5)
- Sign up again by making a POST request to: `http://localhost:3000/auth/register`
```json
{
    "email":"o1234@yopmail.com",
    "password":"123456",
    "first_name":"theNameHere"

}
```
- Check confirmation email

