### PR TITLE
fix:Remove duplicate property names in auth.ts

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -13,8 +13,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/index";
 import { getTenantByEmail, getTenantInfoByUserId } from "../db/models/tenant";
 import { authClient } from "../authClient";
-import 'dotenv/config'
-
+import "dotenv/config";
 
 const router = express.Router();
 
@@ -159,8 +158,6 @@ router.post("/signin", async (req: Request, res: Response) => {
     }
 
     res.cookie("sb-access-token", session.access_token, {
-      httpOnly: true,
-      sameSite: "strict",
       httpOnly: true, //Prevents JS access
       secure: secureFlag, // only sent over HTTPS, set as true only in production
       sameSite: "none",


### PR DESCRIPTION
Removes duplicate cookie properties that crashed backend .
![image](https://github.com/user-attachments/assets/db0bce9f-44ea-4e4d-8a90-0c349b5d8edb)
